### PR TITLE
update App Component generate procedure to latest v1.32

### DIFF
--- a/App Component Tutorial/procedures/AggregateUpdates.generate.vail
+++ b/App Component Tutorial/procedures/AggregateUpdates.generate.vail
@@ -1,10 +1,9 @@
 // Given a component used in a collaboration type, return the assembly entries that should be
 // merged into the containing collaboration type in place of the component.
-PROCEDURE AggregateUpdates.generate(collaborationTypeName String, taskName String) HIDDEN
+PROCEDURE AggregateUpdates.generate(collaborationType ArsCollaborationType, taskName String) HIDDEN
 
-log.debug("AggregateUpdates.generate: beginning generating for task: {} in {}.", [taskName, collaborationTypeName])
+log.debug("AggregateUpdates.generate: beginning generating for task: {} in {}.", [taskName, collaborationType.name])
 
-SELECT ONE FROM collaborationtypes AS collaborationType WHERE name == collaborationTypeName AND ars_namespace == Context.namespace()
 var componentInstance = collaborationType.assembly[taskName]
 componentInstance.name = taskName
 // We need to apply enableBadging to all tasks in this component assembly


### PR DESCRIPTION
The type of the first parameter has changed in 1.32.
Merged in the new boilerplate taken from the 1.32 server on test.

Fixes #52