### PR TITLE
Adjust services to ease migration to 1.35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .DS_Store?
 .idea
+*.iml
 # Misc stuff
 *.tmp
 *.bak

--- a/App Components Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
+++ b/App Components Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
@@ -101,13 +101,11 @@
       "patternVersion" : 1
     },
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "168a8b1a-1ac5-4c54-8184-344e6536066c"
+      "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "EngineMalfunction"
+        }
     },
     "EventStream" : {
       "configuration" : {
@@ -121,13 +119,11 @@
       "uuid" : "bf7d9c5e-fcec-4f35-b84d-6111152828e2"
     },
     "OutboundSpeed" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_Transformation" ],
-        "topic" : "/outbound/engine/speed"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "d8b23334-cf3e-4301-952c-71872f850c7d"
+      "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "OutboundSpeed"
+        }
     }
   },
   "boundService" : "com.vantiq.engines.EngineMonitor",

--- a/App Components Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
+++ b/App Components Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
@@ -119,13 +119,11 @@
       "patternVersion" : 1
     },
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "f86ea40c-25a9-4bd2-80b7-6826c1f33342"
+     "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "EngineMalfunction"
+        }
     },
     "EventStream" : {
       "configuration" : {
@@ -139,13 +137,11 @@
       "uuid" : "30793167-bcf1-4d14-89c5-644c28873fbf"
     },
     "OutboundTemp" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_Transformation" ],
-        "topic" : "/outbound/engine/temp"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "748a0fba-f45b-41c4-9286-bcf3e898e9d2"
+      "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "OutboundTemp"
+        }
     }
   },
   "boundService" : "com.vantiq.engines.EngineMonitor",

--- a/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
+++ b/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
@@ -23,13 +23,14 @@
   "ars_relationships" : [ ],
   "assembly" : {
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "168a8b1a-1ac5-4c54-8184-344e6536066c"
+       "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "EngineMalfunction",
+               "parentStreams": [
+                  "EventStream"
+               ]
+            }
     },
     "EventStream" : {
       "configuration" : {
@@ -43,13 +44,11 @@
       "uuid" : "bf7d9c5e-fcec-4f35-b84d-6111152828e2"
     },
     "OutboundSpeed" : {
-      "configuration" : {
-        "parentStreams" : [ "EventStream" ],
-        "topic" : "/outbound/engine/speed"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "d8b23334-cf3e-4301-952c-71872f850c7d"
+      "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "OutboundSpeed"
+        }
     },
     "generateAlertMessage" : {
       "configuration" : {

--- a/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
+++ b/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
@@ -26,13 +26,11 @@
   "ars_relationships" : [ ],
   "assembly" : {
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "f86ea40c-25a9-4bd2-80b7-6826c1f33342"
+    "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "EngineMalfunction"
+            }
     },
     "EventStream" : {
       "configuration" : {
@@ -46,13 +44,11 @@
       "uuid" : "30793167-bcf1-4d14-89c5-644c28873fbf"
     },
     "OutboundTemp" : {
-      "configuration" : {
-        "parentStreams" : [ "EventStream" ],
-        "topic" : "/outbound/engine/temp"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "748a0fba-f45b-41c4-9286-bcf3e898e9d2"
+      "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "OutboundTemp"
+            }
     },
     "generateAlertMessage" : {
       "configuration" : {

--- a/Stateful Services/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
+++ b/Stateful Services/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
@@ -142,14 +142,11 @@
       "patternVersion" : 1
     },
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "downstreamReferences" : { },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "168a8b1a-1ac5-4c54-8184-344e6536066c"
+      "configuration": {
+         "service": "com.vantiq.engines.EngineMonitor",
+         "eventTypeName": "EngineMalfunction"
+       },   
+      "pattern" : "PublishToEventType"
     },
     "EventStream" : {
       "configuration" : {
@@ -164,14 +161,11 @@
       "uuid" : "bf7d9c5e-fcec-4f35-b84d-6111152828e2"
     },
     "OutboundSpeed" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_Transformation" ],
-        "topic" : "/outbound/engine/speed"
-      },
-      "downstreamReferences" : { },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "d8b23334-cf3e-4301-952c-71872f850c7d"
+      "configuration": {
+         "service": "com.vantiq.engines.EngineMonitor",
+         "eventTypeName": "OutboundSpeed"
+       },   
+      "pattern" : "PublishToEventType"
     }
   },
   "boundService" : "com.vantiq.engines.EngineMonitor",

--- a/Stateful Services/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
+++ b/Stateful Services/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
@@ -157,14 +157,11 @@
       "patternVersion" : 1
     },
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "downstreamReferences" : { },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "f86ea40c-25a9-4bd2-80b7-6826c1f33342"
+      "configuration": {
+         "service": "com.vantiq.engines.EngineMonitor",
+         "eventTypeName": "EngineMalfunction"
+       },   
+      "pattern" : "PublishToEventType"
     },
     "EventStream" : {
       "configuration" : {
@@ -179,14 +176,11 @@
       "uuid" : "30793167-bcf1-4d14-89c5-644c28873fbf"
     },
     "OutboundTemp" : {
-      "configuration" : {
-        "parentStreams" : [ "DetectMalfunction_Transformation" ],
-        "topic" : "/outbound/engine/temp"
-      },
-      "downstreamReferences" : { },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "748a0fba-f45b-41c4-9286-bcf3e898e9d2"
+    "configuration": {
+         "service": "com.vantiq.engines.EngineMonitor",
+         "eventTypeName": "OutboundTemp"
+       },   
+      "pattern" : "PublishToEventType"
     }
   },
   "boundService" : "com.vantiq.engines.EngineMonitor",

--- a/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
+++ b/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SpeedEvent_EventHandler.json
@@ -23,13 +23,14 @@
   "ars_relationships" : [ ],
   "assembly" : {
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "168a8b1a-1ac5-4c54-8184-344e6536066c"
+       "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "EngineMalfunction",
+               "parentStreams": [
+                  "EventStream"
+               ]
+            }
     },
     "EventStream" : {
       "configuration" : {
@@ -43,13 +44,11 @@
       "uuid" : "bf7d9c5e-fcec-4f35-b84d-6111152828e2"
     },
     "OutboundSpeed" : {
-      "configuration" : {
-        "parentStreams" : [ "EventStream" ],
-        "topic" : "/outbound/engine/speed"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "d8b23334-cf3e-4301-952c-71872f850c7d"
+      "pattern": "PublishToEventType",
+        "configuration": {
+           "service": "com.vantiq.engines.EngineMonitor",
+           "eventTypeName": "OutboundSpeed"
+        }
     },
     "generateAlertMessage" : {
       "configuration" : {

--- a/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
+++ b/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_TempEvent_EventHandler.json
@@ -26,13 +26,11 @@
   "ars_relationships" : [ ],
   "assembly" : {
     "EngineMalfunction" : {
-      "configuration" : {
-        "parentStreams" : [ "isMalfunctionDetected" ],
-        "topic" : "/com.vantiq.engines.EngineMonitor/EngineMalfunction/outbound"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "f86ea40c-25a9-4bd2-80b7-6826c1f33342"
+    "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "EngineMalfunction"
+            }
     },
     "EventStream" : {
       "configuration" : {
@@ -46,13 +44,11 @@
       "uuid" : "30793167-bcf1-4d14-89c5-644c28873fbf"
     },
     "OutboundTemp" : {
-      "configuration" : {
-        "parentStreams" : [ "EventStream" ],
-        "topic" : "/outbound/engine/temp"
-      },
-      "pattern" : "PublishToTopic",
-      "patternVersion" : 1,
-      "uuid" : "748a0fba-f45b-41c4-9286-bcf3e898e9d2"
+      "pattern": "PublishToEventType",
+            "configuration": {
+               "service": "com.vantiq.engines.EngineMonitor",
+               "eventTypeName": "OutboundTemp"
+            }
     },
     "generateAlertMessage" : {
       "configuration" : {

--- a/Test Introductory Tutorial/services/com/vantiq/engines/EngineMonitor.json
+++ b/Test Introductory Tutorial/services/com/vantiq/engines/EngineMonitor.json
@@ -37,9 +37,10 @@
   },
   "globalType" : null,
   "interface" : [ {
+    "description" : "given a temperature or speed event, determine the alert message (if any)",
     "name" : "generateAlertMessage",
     "parameters" : [ {
-      "description" : null,
+      "description" : "speed or temperature sensor event",
       "multi" : false,
       "name" : "sensorEvent",
       "required" : false,

--- a/Test Introductory Tutorial/services/com/vantiq/engines/EngineMonitor.json
+++ b/Test Introductory Tutorial/services/com/vantiq/engines/EngineMonitor.json
@@ -37,10 +37,9 @@
   },
   "globalType" : null,
   "interface" : [ {
-    "description" : "given a temperature or speed event, determine the alert message (if any)",
     "name" : "generateAlertMessage",
     "parameters" : [ {
-      "description" : "speed or temperature sensor event",
+      "description" : null,
       "multi" : false,
       "name" : "sensorEvent",
       "required" : false,


### PR DESCRIPTION
With the exception of the weather app in the assembly tutorial, all the others should import in this form into 1.35 with only warnings.

Fixes #74