### PR TITLE
Fix references to NoSpeed

### DIFF
--- a/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_SensorReading1_EventHandler.json
+++ b/Introductory/collaborationtypes/com/vantiq/engines/EngineMonitor_SensorReading1_EventHandler.json
@@ -6,61 +6,61 @@
     "graph" : {
       "coordinates" : {
         "14ce9624-7785-4074-85ea-0b7bc8b86f3e" : {
-          "x" : 107.5,
-          "y" : 200
+          "x" : 224.98296592278865,
+          "y" : 203.91609886409293
         },
         "16dd3051-0937-45e6-8a18-1051b1ac72ee" : {
-          "x" : 0,
-          "y" : 0
+          "x" : 110.95613448263379,
+          "y" : -3.916098864092957
         },
         "2f030ec9-6dd2-4e33-8ff5-9ae742857d47" : {
-          "x" : -69.83203125,
-          "y" : 345
+          "x" : 40.889051890806286,
+          "y" : 348.91609886409293
         },
         "51ce1357-7ca6-4563-8536-8c1b4459546c" : {
-          "x" : -215,
-          "y" : 298.694633711969
+          "x" : 117.48296592278871,
+          "y" : 296.083901135907
         },
         "589360ab-edd2-46f6-b5c8-d7816e67095f" : {
-          "x" : -26.193084716796875,
-          "y" : 194.35272320620896
+          "x" : 91.28988120599183,
+          "y" : 191.08390113590704
         },
         "74c40a26-a2c9-4aae-89e0-8f22035874aa" : {
-          "x" : -107.5,
-          "y" : 200
+          "x" : 9.982965922788715,
+          "y" : 196.08390113590704
         },
         "768bc4af-d0e2-433d-9559-7e4a962e3de1" : {
-          "x" : -215,
-          "y" : 400
+          "x" : 117.48296592278871,
+          "y" : 403.91609886409293
         },
         "9e2cde60-f6d2-4495-8951-fea583f084c1" : {
-          "x" : -107.5,
-          "y" : 100
+          "x" : 9.982965922788715,
+          "y" : 96.08390113590704
         },
         "a251719d-8f22-41c5-8dce-f00a3026f19d" : {
-          "x" : -107.5,
-          "y" : 500
+          "x" : 9.982965922788665,
+          "y" : 503.91609886409293
         },
         "ba97bf9f-7a35-41ef-8f99-c971b1a1e24d" : {
-          "x" : 0,
-          "y" : 300
+          "x" : -97.51703407721119,
+          "y" : 296.083901135907
         },
         "cbcdc104-880b-42df-9298-af496ff90ec7" : {
-          "x" : 107.5,
-          "y" : 98.70544641241793
+          "x" : 224.98296592278888,
+          "y" : 96.08390113590704
         },
         "ea2ac370-9201-425a-8da3-82c58bcb2e57" : {
-          "x" : 0,
-          "y" : -5
+          "x" : 110.95613448263379,
+          "y" : -8.916098864092957
         },
         "f4cc1aeb-f0ae-48c0-912a-21895b7648cd" : {
-          "x" : 0,
-          "y" : 400
+          "x" : -97.5170340772113,
+          "y" : 403.91609886409293
         }
       },
-      "lastZoomRequest" : 0,
+      "lastZoomRequest" : 2,
       "scale" : 0.7660685044259875,
-      "translate" : [ 433.8993354343657, 75.0176417961448 ]
+      "translate" : [ 213.6750648739121, 60.730828599691336 ]
     },
     "groupSettings" : {
       "appGroupOpenHash" : {
@@ -107,7 +107,7 @@
   },
   "ars_relationships" : [ ],
   "assembly" : {
-    "AddNoSpeedOverheat" : {
+    "AddNonSpeedOverheat" : {
       "configuration" : {
         "childStreams" : [ "PublishStatus" ],
         "imports" : null,
@@ -127,7 +127,7 @@
       },
       "context" : "React",
       "downstreamReferences" : { },
-      "name" : "AddNoSpeedOverheat",
+      "name" : "AddNonSpeedOverheat",
       "pattern" : "Transformation",
       "patternVersion" : 2,
       "uuid" : "f4cc1aeb-f0ae-48c0-912a-21895b7648cd"
@@ -206,7 +206,7 @@
     },
     "NonSpeedOverheat" : {
       "configuration" : {
-        "childStreams" : [ "AddNoSpeedOverheat" ],
+        "childStreams" : [ "AddNonSpeedOverheat" ],
         "condition" : [ {
           "expression" : "null",
           "op" : "!=",
@@ -256,7 +256,7 @@
       "configuration" : {
         "childStreams" : null,
         "eventTypeName" : "EngineStatus",
-        "parentStreams" : [ "AddNoSpeedOverheat", "AddSpeedOverheat", "ClearAlert" ],
+        "parentStreams" : [ "AddNonSpeedOverheat", "AddSpeedOverheat", "ClearAlert" ],
         "processedByClause" : null,
         "service" : "com.vantiq.engines.EngineMonitor"
       },

--- a/Introductory/projects/EngineMonitorProject.json
+++ b/Introductory/projects/EngineMonitorProject.json
@@ -64,8 +64,8 @@
     "source" : "client/com.vantiq.engines.EngineMonitor",
     "target" : "services/com.vantiq.engines.EngineMonitor"
   }, {
-    "source" : "app/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
-    "target" : "source/com.vantiq.engines.TemperatureSensor"
+    "source" : "designmodel/com.vantiq.engines.EngineMonitor",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
   }, {
     "source" : "app/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
     "target" : "source/com.vantiq.engines.SpeedSensor"
@@ -73,8 +73,32 @@
     "source" : "designmodel/com.vantiq.engines.EngineMonitor",
     "target" : "client/com.vantiq.engines.EngineMonitor"
   }, {
-    "source" : "designmodel/com.vantiq.engines.EngineMonitor",
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat",
     "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_RetrieveSpeed",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_RetrieveSpeed"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_RetrieveSpeed",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.speedGet"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNonSpeedOverheat",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNonSpeedOverheat"
   } ],
   "name" : "EngineMonitorProject",
   "options" : {
@@ -112,31 +136,31 @@
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.designmodels/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:41.279Z",
+    "timestamp" : "2023-01-11T01:48:33.219Z",
     "type" : 75
   }, {
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.services/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:49.186Z",
+    "timestamp" : "2023-01-11T01:48:33.860Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.clients/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:41.573Z",
+    "timestamp" : "2023-01-11T01:48:32.554Z",
     "type" : 15
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.GlobalAppState",
     "name" : "com.vantiq.engines.EngineMonitor.GlobalAppState",
     "resourceReference" : "/types/com.vantiq.engines.EngineMonitor.GlobalAppState",
-    "timestamp" : "2023-01-05T00:26:40.859Z",
+    "timestamp" : "2023-01-11T01:48:32.340Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.js",
     "name" : "com.vantiq.engines.EngineMonitor.js",
     "resourceReference" : "/documents/com.vantiq.engines.EngineMonitor.js",
-    "timestamp" : "2023-01-05T00:26:52.131Z",
+    "timestamp" : "2023-01-11T01:48:34.542Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedGet",
@@ -145,7 +169,7 @@
     "procedureName" : "speedGet",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedGet",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:46.628Z",
+    "timestamp" : "2023-01-11T01:48:37.670Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedReset",
@@ -154,7 +178,7 @@
     "procedureName" : "speedReset",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedReset",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:52.423Z",
+    "timestamp" : "2023-01-11T01:48:38.508Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedUpdate",
@@ -163,67 +187,67 @@
     "procedureName" : "speedUpdate",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedUpdate",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-05T00:26:49.014Z",
+    "timestamp" : "2023-01-11T01:48:38.181Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
     "name" : "com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
-    "timestamp" : "2023-01-05T00:26:45.352Z",
+    "timestamp" : "2023-01-11T01:48:35.190Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
     "name" : "com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
-    "timestamp" : "2023-01-05T00:26:43.605Z",
+    "timestamp" : "2023-01-11T01:50:35.269Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService",
     "resourceReference" : "/system.services/com.vantiq.engines.IngestExternalSensorEventsService",
-    "timestamp" : "2023-01-05T00:26:42.589Z",
+    "timestamp" : "2023-01-11T01:48:34.008Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
-    "timestamp" : "2023-01-05T00:26:43.459Z",
+    "timestamp" : "2023-01-11T01:48:34.856Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
-    "timestamp" : "2023-01-05T00:26:43.456Z",
+    "timestamp" : "2023-01-11T01:48:34.856Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.js",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.js",
     "resourceReference" : "/documents/com.vantiq.engines.IngestExternalSensorEventsService.js",
-    "timestamp" : "2023-01-05T00:26:42.844Z",
+    "timestamp" : "2023-01-11T01:48:34.298Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.engines.SpeedEvent",
     "name" : "com.vantiq.engines.SpeedEvent",
     "resourceReference" : "/types/com.vantiq.engines.SpeedEvent",
-    "timestamp" : "2023-01-05T00:26:40.858Z",
+    "timestamp" : "2023-01-11T01:48:32.340Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.SpeedSensor",
     "name" : "com.vantiq.engines.SpeedSensor",
     "resourceReference" : "/sources/com.vantiq.engines.SpeedSensor",
-    "timestamp" : "2023-01-05T00:26:42.085Z",
+    "timestamp" : "2023-01-11T01:48:33.577Z",
     "type" : 4
   }, {
     "label" : "com.vantiq.engines.StatusEvent",
     "name" : "com.vantiq.engines.StatusEvent",
     "resourceReference" : "/types/com.vantiq.engines.StatusEvent",
-    "timestamp" : "2023-01-05T00:26:40.858Z",
+    "timestamp" : "2023-01-11T01:48:32.347Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.TemperatureSensor",
     "name" : "com.vantiq.engines.TemperatureSensor",
     "resourceReference" : "/sources/com.vantiq.engines.TemperatureSensor",
-    "timestamp" : "2023-01-05T00:26:42.085Z",
+    "timestamp" : "2023-01-11T01:48:33.577Z",
     "type" : 4
   } ],
   "tools" : [ {
@@ -277,13 +301,23 @@
       "c" : 1,
       "r" : 0
     },
-    "resourceKey" : "designmodel/com.vantiq.engines.EngineMonitor",
+    "resourceKey" : "services/com.vantiq.engines.EngineMonitor",
     "state" : 2,
+    "type" : 109
+  }, {
+    "isPinned" : false,
+    "name" : "com.vantiq.engines.EngineMonitor",
+    "pane" : {
+      "c" : -1,
+      "r" : -1
+    },
+    "resourceKey" : "designmodel/com.vantiq.engines.EngineMonitor",
+    "state" : 4,
     "type" : 121
   } ],
   "type" : "dev",
   "views" : [ {
     "name" : "Project Contents",
-    "projectToolKeys" : [ "activeResources/Active Resource Control Center", "errorviewer/Errors", "tiledock/Inactive Panes", "list/Project Contents", "projectdescription/Project Description", "client/com.vantiq.engines.EngineMonitor", "designmodel/com.vantiq.engines.EngineMonitor" ]
+    "projectToolKeys" : [ "activeResources/Active Resource Control Center", "errorviewer/Errors", "tiledock/Inactive Panes", "list/Project Contents", "projectdescription/Project Description", "client/com.vantiq.engines.EngineMonitor", "services/com.vantiq.engines.EngineMonitor", "designmodel/com.vantiq.engines.EngineMonitor" ]
   } ]
 }

--- a/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SensorReading1_EventHandler.json
+++ b/Test Introductory Tutorial/collaborationtypes/com/vantiq/engines/EngineMonitor_SensorReading1_EventHandler.json
@@ -19,11 +19,11 @@
         },
         "51ce1357-7ca6-4563-8536-8c1b4459546c" : {
           "x" : -215,
-          "y" : 298.694633711969
+          "y" : 300
         },
         "589360ab-edd2-46f6-b5c8-d7816e67095f" : {
           "x" : -26.193084716796875,
-          "y" : 194.35272320620896
+          "y" : 195
         },
         "74c40a26-a2c9-4aae-89e0-8f22035874aa" : {
           "x" : -107.5,
@@ -47,7 +47,7 @@
         },
         "cbcdc104-880b-42df-9298-af496ff90ec7" : {
           "x" : 107.5,
-          "y" : 98.70544641241793
+          "y" : 100
         },
         "ea2ac370-9201-425a-8da3-82c58bcb2e57" : {
           "x" : 0,
@@ -107,7 +107,7 @@
   },
   "ars_relationships" : [ ],
   "assembly" : {
-    "AddNoSpeedOverheat" : {
+    "AddNonSpeedOverheat" : {
       "configuration" : {
         "childStreams" : [ "PublishStatus" ],
         "imports" : null,
@@ -127,7 +127,7 @@
       },
       "context" : "React",
       "downstreamReferences" : { },
-      "name" : "AddNoSpeedOverheat",
+      "name" : "AddNonSpeedOverheat",
       "pattern" : "Transformation",
       "patternVersion" : 2,
       "uuid" : "f4cc1aeb-f0ae-48c0-912a-21895b7648cd"
@@ -206,7 +206,7 @@
     },
     "NonSpeedOverheat" : {
       "configuration" : {
-        "childStreams" : [ "AddNoSpeedOverheat" ],
+        "childStreams" : [ "AddNonSpeedOverheat" ],
         "condition" : [ {
           "expression" : "null",
           "op" : "!=",
@@ -256,7 +256,7 @@
       "configuration" : {
         "childStreams" : null,
         "eventTypeName" : "EngineStatus",
-        "parentStreams" : [ "AddNoSpeedOverheat", "AddSpeedOverheat", "ClearAlert" ],
+        "parentStreams" : [ "AddNonSpeedOverheat", "AddSpeedOverheat", "ClearAlert" ],
         "processedByClause" : null,
         "service" : "com.vantiq.engines.EngineMonitor"
       },

--- a/Test Introductory Tutorial/projects/EngineMonitorProject.json
+++ b/Test Introductory Tutorial/projects/EngineMonitorProject.json
@@ -91,12 +91,6 @@
     "source" : "services/com.vantiq.engines.EngineMonitor",
     "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat"
   }, {
-    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNoSpeedOverheat",
-    "target" : "services/com.vantiq.engines.EngineMonitor"
-  }, {
-    "source" : "services/com.vantiq.engines.EngineMonitor",
-    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNoSpeedOverheat"
-  }, {
     "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert",
     "target" : "services/com.vantiq.engines.EngineMonitor"
   }, {

--- a/Test Introductory Tutorial/projects/EngineMonitorProject.json
+++ b/Test Introductory Tutorial/projects/EngineMonitorProject.json
@@ -70,26 +70,11 @@
     "source" : "test/com.vantiq.engines.EngineMonitorTest",
     "target" : "services/com.vantiq.engines.EngineMonitor"
   }, {
-    "source" : "app/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
-    "target" : "source/com.vantiq.engines.TemperatureSensor"
-  }, {
-    "source" : "app/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
-    "target" : "source/com.vantiq.engines.SpeedSensor"
-  }, {
     "source" : "designmodel/com.vantiq.engines.EngineMonitor",
     "target" : "client/com.vantiq.engines.EngineMonitor"
   }, {
-    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat",
-    "target" : "services/com.vantiq.engines.EngineMonitor"
-  }, {
-    "source" : "services/com.vantiq.engines.EngineMonitor",
-    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat"
-  }, {
-    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert",
-    "target" : "services/com.vantiq.engines.EngineMonitor"
-  }, {
-    "source" : "services/com.vantiq.engines.EngineMonitor",
-    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert"
+    "source" : "app/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
+    "target" : "source/com.vantiq.engines.SpeedSensor"
   }, {
     "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_RetrieveSpeed",
     "target" : "services/com.vantiq.engines.EngineMonitor"
@@ -100,11 +85,29 @@
     "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_RetrieveSpeed",
     "target" : "procedure/com.vantiq.engines.EngineMonitor.speedGet"
   }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddSpeedOverheat"
+  }, {
     "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNoSpeedOverheat",
     "target" : "services/com.vantiq.engines.EngineMonitor"
   }, {
     "source" : "services/com.vantiq.engines.EngineMonitor",
     "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNoSpeedOverheat"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_ClearAlert"
+  }, {
+    "source" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNonSpeedOverheat",
+    "target" : "services/com.vantiq.engines.EngineMonitor"
+  }, {
+    "source" : "services/com.vantiq.engines.EngineMonitor",
+    "target" : "procedure/com.vantiq.engines.EngineMonitor.EngineMonitor_SensorReading1_EventHandler_AddNonSpeedOverheat"
   } ],
   "name" : "EngineMonitorProject",
   "options" : {
@@ -142,31 +145,31 @@
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.designmodels/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:11.131Z",
+    "timestamp" : "2023-01-11T16:38:55.789Z",
     "type" : 75
   }, {
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.services/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:12.270Z",
+    "timestamp" : "2023-01-11T16:38:56.437Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.engines.EngineMonitor",
     "name" : "com.vantiq.engines.EngineMonitor",
     "resourceReference" : "/system.clients/com.vantiq.engines.EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:11.461Z",
+    "timestamp" : "2023-01-11T16:38:54.957Z",
     "type" : 15
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.GlobalAppState",
     "name" : "com.vantiq.engines.EngineMonitor.GlobalAppState",
     "resourceReference" : "/types/com.vantiq.engines.EngineMonitor.GlobalAppState",
-    "timestamp" : "2023-01-09T21:23:10.748Z",
+    "timestamp" : "2023-01-11T16:38:54.379Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.js",
     "name" : "com.vantiq.engines.EngineMonitor.js",
     "resourceReference" : "/documents/com.vantiq.engines.EngineMonitor.js",
-    "timestamp" : "2023-01-09T21:23:12.820Z",
+    "timestamp" : "2023-01-11T16:38:57.200Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedGet",
@@ -175,7 +178,7 @@
     "procedureName" : "speedGet",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedGet",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:15.510Z",
+    "timestamp" : "2023-01-11T16:39:00.343Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedReset",
@@ -184,7 +187,7 @@
     "procedureName" : "speedReset",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedReset",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:16.680Z",
+    "timestamp" : "2023-01-11T16:39:01.136Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitor.speedUpdate",
@@ -193,73 +196,73 @@
     "procedureName" : "speedUpdate",
     "resourceReference" : "/procedures/com.vantiq.engines.EngineMonitor.speedUpdate",
     "serviceName" : "EngineMonitor",
-    "timestamp" : "2023-01-09T21:23:16.367Z",
+    "timestamp" : "2023-01-11T16:39:00.793Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.engines.EngineMonitorTest",
     "name" : "com.vantiq.engines.EngineMonitorTest",
     "resourceReference" : "/system.tests/com.vantiq.engines.EngineMonitorTest",
-    "timestamp" : "2023-01-09T21:23:17.319Z",
+    "timestamp" : "2023-01-11T16:39:01.757Z",
     "type" : 56
   }, {
     "label" : "com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
     "name" : "com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.EngineMonitor_SensorReading0_EventHandler",
-    "timestamp" : "2023-01-09T21:23:13.514Z",
+    "timestamp" : "2023-01-11T16:38:57.794Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
     "name" : "com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.EngineMonitor_SensorReading1_EventHandler",
-    "timestamp" : "2023-01-09T21:23:13.259Z",
+    "timestamp" : "2023-01-11T16:40:10.205Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService",
     "resourceReference" : "/system.services/com.vantiq.engines.IngestExternalSensorEventsService",
-    "timestamp" : "2023-01-09T21:23:12.435Z",
+    "timestamp" : "2023-01-11T16:38:56.621Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents0",
-    "timestamp" : "2023-01-09T21:23:13.249Z",
+    "timestamp" : "2023-01-11T16:38:57.533Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
     "resourceReference" : "/collaborationtypes/com.vantiq.engines.IngestExternalSensorEventsService.IngestExternalEvents1",
-    "timestamp" : "2023-01-09T21:23:13.246Z",
+    "timestamp" : "2023-01-11T16:38:57.532Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.engines.IngestExternalSensorEventsService.js",
     "name" : "com.vantiq.engines.IngestExternalSensorEventsService.js",
     "resourceReference" : "/documents/com.vantiq.engines.IngestExternalSensorEventsService.js",
-    "timestamp" : "2023-01-09T21:23:12.822Z",
+    "timestamp" : "2023-01-11T16:38:56.965Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.engines.SpeedEvent",
     "name" : "com.vantiq.engines.SpeedEvent",
     "resourceReference" : "/types/com.vantiq.engines.SpeedEvent",
-    "timestamp" : "2023-01-09T21:23:10.744Z",
+    "timestamp" : "2023-01-11T16:38:54.380Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.SpeedSensor",
     "name" : "com.vantiq.engines.SpeedSensor",
     "resourceReference" : "/sources/com.vantiq.engines.SpeedSensor",
-    "timestamp" : "2023-01-09T21:23:11.958Z",
+    "timestamp" : "2023-01-11T16:38:56.087Z",
     "type" : 4
   }, {
     "label" : "com.vantiq.engines.StatusEvent",
     "name" : "com.vantiq.engines.StatusEvent",
     "resourceReference" : "/types/com.vantiq.engines.StatusEvent",
-    "timestamp" : "2023-01-09T21:23:10.747Z",
+    "timestamp" : "2023-01-11T16:38:54.379Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.engines.TemperatureSensor",
     "name" : "com.vantiq.engines.TemperatureSensor",
     "resourceReference" : "/sources/com.vantiq.engines.TemperatureSensor",
-    "timestamp" : "2023-01-09T21:23:11.958Z",
+    "timestamp" : "2023-01-11T16:38:56.086Z",
     "type" : 4
   } ],
   "tools" : [ {


### PR DESCRIPTION
For whatever reason, the Test Intro tutorial Project description still contains references to the 'NoSpeed' version in the links property. These appear harmless and have to do with server relationships data that didn't get updated. The Resource Graph appears correct.