### PR TITLE
Fixes #98. remove unused "Chat" activity from WarnNotification event handler of Assembly Tutorial.

### DIFF
--- a/Assembly Tutorial/collaborationtypes/com/vantiq/weatherEmergencies/DetectWeatherEmergency/WarnNotification.json
+++ b/Assembly Tutorial/collaborationtypes/com/vantiq/weatherEmergencies/DetectWeatherEmergency/WarnNotification.json
@@ -5,16 +5,12 @@
     "dataVersion" : 5,
     "graph" : {
       "coordinates" : {
-        "Chat" : {
-          "x" : 97.5,
-          "y" : 80
-        },
         "EventStream" : {
           "x" : 0,
           "y" : 0
         },
         "WarningEvent" : {
-          "x" : -97.5,
+          "x" : 0,
           "y" : 80
         }
       },
@@ -39,18 +35,6 @@
   },
   "ars_relationships" : [ ],
   "assembly" : {
-    "Chat" : {
-      "configuration" : {
-        "chatbotSourceName" : null,
-        "imports" : null,
-        "parentStreams" : [ ],
-        "users" : null
-      },
-      "downstreamReferences" : { },
-      "pattern" : "Chat",
-      "patternVersion" : 1,
-      "uuid" : "f372ce12-0226-46f2-931a-84c87a6c7ca3"
-    },
     "EventStream" : {
       "configuration" : {
         "childStreams" : [ "WarningEvent" ],


### PR DESCRIPTION
I tested it by importing the tutorial project from my local drive and verify the project and run as expected.
Visually inspect the WarnNotification event handler.