### PR TITLE
Update Collaboration Tutorials for 1.38

### DIFF
--- a/Advanced Collaborations/clients/FirstResponderResponse.json
+++ b/Advanced Collaborations/clients/FirstResponderResponse.json
@@ -61,8 +61,7 @@
   "resourceBinding" : {
     "requiredResources" : [ {
       "resource" : "topics",
-      "resourceId" : "/vantiq/systemmodel/FirstResponderResponse/submitTopic",
-      "type" : "publishes"
+      "resourceId" : "/vantiq/systemmodel/FirstResponderResponse/submitTopic"
     } ]
   },
   "targetDevice" : "mobile",

--- a/Advanced Collaborations/collaborationtypes/patient/monitoring/HeartRate/MonitorReading.json
+++ b/Advanced Collaborations/collaborationtypes/patient/monitoring/HeartRate/MonitorReading.json
@@ -34,6 +34,7 @@
         "Utils" : true
       }
     },
+    "isHidden" : false,
     "paletteWidth" : 170,
     "propertyWidth" : 280
   },
@@ -48,8 +49,9 @@
         "roleType" : "collaborator"
       },
       "downstreamReferences" : { },
+      "name" : "AssignCollaborator",
       "pattern" : "Assign",
-      "patternVersion" : 1,
+      "patternVersion" : 7,
       "uuid" : "3d1ee379-912d-495e-9315-6458be13cd6c"
     },
     "AssignPatient" : {
@@ -61,8 +63,9 @@
         "roleType" : "entity"
       },
       "downstreamReferences" : { },
+      "name" : "AssignPatient",
       "pattern" : "Assign",
-      "patternVersion" : 1,
+      "patternVersion" : 7,
       "uuid" : "ad41cf72-bca2-4b06-99af-f6bc8c1468ff"
     },
     "AwaitResponse" : {
@@ -73,8 +76,9 @@
         "parentStreams" : [ "NotifyFirstResponder" ]
       },
       "downstreamReferences" : { },
+      "name" : "AwaitResponse",
       "pattern" : "Delay",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "34418a0a-1590-4319-8f14-ca403477d5c3"
     },
     "CollabComplete" : {
@@ -83,8 +87,9 @@
         "status" : "completed"
       },
       "downstreamReferences" : { },
+      "name" : "CollabComplete",
       "pattern" : "CollaborationStatus",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "5d4d575e-d0f8-47cc-85d6-2b3784652add"
     },
     "CollabFailed" : {
@@ -93,22 +98,24 @@
         "status" : "failed"
       },
       "downstreamReferences" : { },
+      "name" : "CollabFailed",
       "pattern" : "CollaborationStatus",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "6ebc102a-1323-4f07-9884-2924697822ce"
     },
     "EventStream" : {
       "configuration" : {
         "childStreams" : [ "isUnusualHeartRate" ],
+        "eventTypeName" : "MonitorReading",
         "inboundResource" : "services",
         "inboundResourceId" : "patient.monitoring.HeartRate",
-        "eventTypeName": "MonitorReading",
         "parentStreams" : [ ]
       },
       "description" : "w",
       "downstreamReferences" : { },
+      "name" : "EventStream",
       "pattern" : "EventStream",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "17dafa82-936d-416f-81c5-f87867003413"
     },
     "FindResponders" : {
@@ -128,8 +135,9 @@
         "returnProperty" : "recommendedResponders"
       },
       "downstreamReferences" : { },
+      "name" : "FindResponders",
       "pattern" : "Recommend",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "c4a8633b-7079-4dfe-991b-1e8ea415ce86"
     },
     "GetFirstResponder" : {
@@ -141,8 +149,9 @@
         "taskName" : "firstResponder"
       },
       "downstreamReferences" : { },
+      "name" : "GetFirstResponder",
       "pattern" : "GetCollaboration",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "3ed55662-dba4-4638-a69e-0446a1429485"
     },
     "GetPatient" : {
@@ -154,8 +163,9 @@
         "taskName" : "patient"
       },
       "downstreamReferences" : { },
+      "name" : "GetPatient",
       "pattern" : "GetCollaboration",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "9ca8fbd7-e1b2-412d-8e41-bfd1a820e9b3"
     },
     "GetPatientLocation" : {
@@ -167,8 +177,9 @@
         "taskName" : "patient"
       },
       "downstreamReferences" : { },
+      "name" : "GetPatientLocation",
       "pattern" : "GetCollaboration",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "f2a07826-feb2-4183-9899-a7f62c6998d3"
     },
     "GetPayloadId" : {
@@ -180,8 +191,9 @@
         "taskName" : "NotifyFirstResponder"
       },
       "downstreamReferences" : { },
+      "name" : "GetPayloadId",
       "pattern" : "GetCollaboration",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "478b26e8-e9b5-48f0-b9f3-dab1e64201c2"
     },
     "HelpNeeded" : {
@@ -196,13 +208,14 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "HelpNeeded",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "95aedb54-73c7-4a4a-b760-c88bf2a44b2d"
     },
     "LoopWhile" : {
       "configuration" : {
-        "condition" : "counter < length(event.recommendedResponders) && (HeartRate.ActiveCollabsGetById_MonitorReading(collaborationId, \"firstResponder\") == null)",
+        "condition" : "counter < length(event.recommendedResponders) && (HeartRate.ActiveCollabsGetById(collaborationId, \"firstResponder\") == null)",
         "counterProperty" : "counter",
         "imports" : null,
         "maxRetryCount" : null,
@@ -217,7 +230,7 @@
       },
       "name" : "LoopWhile",
       "pattern" : "LoopWhile",
-      "patternVersion" : 1,
+      "patternVersion" : 2,
       "uuid" : "aa438041-cccb-485c-8cfa-c4af67ff5bb0"
     },
     "NoResponder" : {
@@ -232,8 +245,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "NoResponder",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "b164ba2f-4867-4e1f-aa18-cc1c33dd9f4e"
     },
     "NoResponse" : {
@@ -248,8 +262,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "NoResponse",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "0a8b7bf2-d288-4bae-8429-f5cf2c10f287"
     },
     "NotifyFirstResponder" : {
@@ -272,8 +287,9 @@
       "downstreamUUIDS" : {
         "response" : "27715a60-ecae-452e-8405-975cb159f628"
       },
+      "name" : "NotifyFirstResponder",
       "pattern" : "Notify",
-      "patternVersion" : 1,
+      "patternVersion" : 6,
       "uuid" : "41b0e8ed-6667-4bb3-8bee-24a993a14310"
     },
     "NotifyPatient" : {
@@ -298,8 +314,9 @@
         "response" : "63a76ed9-15db-42c0-8f37-80953753d6ca",
         "responseTimeout" : "8898cd9f-3b67-43f2-84be-9224f7f88967"
       },
+      "name" : "NotifyPatient",
       "pattern" : "Notify",
-      "patternVersion" : 1,
+      "patternVersion" : 6,
       "uuid" : "93647c35-788d-4d1f-a6a8-9532a3522871"
     },
     "OK" : {
@@ -314,8 +331,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "OK",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "8b3a10b2-6569-44d4-8e6b-57b5ee13014f"
     },
     "PatientOK" : {
@@ -324,8 +342,9 @@
         "status" : "completed"
       },
       "downstreamReferences" : { },
+      "name" : "PatientOK",
       "pattern" : "CollaborationStatus",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "f491fcc0-2ebb-4214-8f31-1bc4b4bf60bd"
     },
     "ResponderArrived" : {
@@ -340,8 +359,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "ResponderArrived",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "dd170da3-8334-44cc-8d46-c2343334c419"
     },
     "RetractMsg" : {
@@ -359,8 +379,9 @@
         "schema" : null
       },
       "downstreamReferences" : { },
+      "name" : "RetractMsg",
       "pattern" : "Procedure",
-      "patternVersion" : 1,
+      "patternVersion" : 3,
       "uuid" : "d0acb5e4-d8b5-48c7-8a12-36e09380c008"
     },
     "TrackResponder" : {
@@ -385,8 +406,9 @@
       "downstreamUUIDS" : {
         "update" : "4b30259f-bfb7-48dd-9bbf-26f678f12d97"
       },
+      "name" : "TrackResponder",
       "pattern" : "Track",
-      "patternVersion" : 1,
+      "patternVersion" : 5,
       "uuid" : "8b1ddc19-23c2-41f8-b04d-defbb8b5c435"
     },
     "isUnusualHeartRate" : {
@@ -401,21 +423,16 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "isUnusualHeartRate",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "bfafe3fc-093d-48d9-920c-e5e376af2edb"
     }
   },
-  "boundService" : "patient.monitoring.HeartRate",
-  "collaboratorRoles" : [ "firstResponder" ],
+  "contextualizedAssembly" : { },
   "disableBadging" : false,
-  "entityRoles" : [ {
-    "name" : "patient",
-    "type" : "patient.monitoring.HeartRate.MonitorReading"
-  } ],
   "isComponent" : false,
   "isEventHandler" : true,
   "keyTypes" : [ "system.collaborations" ],
-  "name" : "patient.monitoring.HeartRate.MonitorReading",
-  "writeFrequency" : "5 minutes"
+  "name" : "patient.monitoring.HeartRate.MonitorReading"
 }

--- a/Advanced Collaborations/data/FirstResponder.json
+++ b/Advanced Collaborations/data/FirstResponder.json
@@ -7,16 +7,16 @@
   "username" : "<YOUR USERNAME>"
 }, {
   "location" : {
-    "coordinates" : [ -122.27304, 37.8715 ],
-    "type" : "Point"
-  },
-  "name" : "Sarah Brown",
-  "username" : "<YOUR USERNAME>"
-}, {
-  "location" : {
     "coordinates" : [ -122.2892, 37.8395 ],
     "type" : "Point"
   },
   "name" : "Robert Johnson",
+  "username" : "<YOUR USERNAME>"
+}, {
+  "location" : {
+    "coordinates" : [ -122.27304, 37.8715 ],
+    "type" : "Point"
+  },
+  "name" : "Sarah Brown",
   "username" : "<YOUR USERNAME>"
 } ]

--- a/Advanced Collaborations/projects/PatientMonitor.json
+++ b/Advanced Collaborations/projects/PatientMonitor.json
@@ -5,9 +5,6 @@
     "target" : "document/patient.monitoring.HeartRate.js"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "topic//patient.monitoring.HeartRate/MonitorReading/handler/inbound"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.generateHeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.generateHeartRate",
@@ -23,136 +20,169 @@
     "target" : "topic//vantiq/systemmodel/FirstResponderResponse/submitTopic"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading"
+    "target" : "app/patient.monitoring.HeartRate.MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading"
+    "target" : "type/patient.monitoring.HeartRate.MonitorReading"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
+    "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose",
+    "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateReset_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading"
   }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.LoopWhileStateReset_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
+    "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
   }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
     "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
   }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
     "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading"
   }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
     "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading"
@@ -161,31 +191,19 @@
     "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading"
   }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
     "target" : "procedure/patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading"
   }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading"
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
   }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "app/patient.monitoring.HeartRate.MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "type/patient.monitoring.HeartRate.MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
   }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "type/patient.monitoring.HeartRate.MonitorReading"
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
   } ],
   "name" : "PatientMonitor",
   "options" : {
@@ -218,6 +236,7 @@
     "v" : 5,
     "viewUUID" : "MAINVIEW"
   },
+  "partitions" : [ ],
   "resources" : [ {
     "label" : "/patient.monitoring.HeartRate/MonitorReading/handler/inbound",
     "name" : "/patient.monitoring.HeartRate/MonitorReading/handler/inbound",
@@ -237,185 +256,195 @@
     "label" : "FirstResponder",
     "name" : "FirstResponder",
     "resourceReference" : "/types/FirstResponder",
-    "timestamp" : "2023-01-26T16:19:29.713Z",
+    "timestamp" : "2023-12-06T18:05:47.688Z",
     "type" : 1
   }, {
     "label" : "FirstResponderResponse",
     "name" : "FirstResponderResponse",
     "resourceReference" : "/system.clients/FirstResponderResponse",
-    "timestamp" : "2023-01-26T16:19:29.776Z",
+    "timestamp" : "2023-12-06T18:05:48.810Z",
     "type" : 15
   }, {
     "label" : "PatientResponse",
     "name" : "PatientResponse",
     "resourceReference" : "/system.clients/PatientResponse",
-    "timestamp" : "2023-01-26T16:19:29.776Z",
+    "timestamp" : "2023-12-06T18:05:48.810Z",
     "type" : 15
   }, {
     "label" : "patient.monitoring.HeartRate",
     "name" : "patient.monitoring.HeartRate",
     "resourceReference" : "/system.services/patient.monitoring.HeartRate",
-    "timestamp" : "2023-01-26T16:19:43.035Z",
+    "timestamp" : "2023-12-06T18:08:11.188Z",
     "type" : 63
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsCloseAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
+    "procedureName" : "ActiveCollabsCloseAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:40.488Z",
+    "timestamp" : "2023-12-06T18:05:51.493Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsGetAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
+    "procedureName" : "ActiveCollabsGetAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:37.667Z",
+    "timestamp" : "2023-12-06T18:05:50.658Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetById",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsGetById_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
+    "procedureName" : "ActiveCollabsGetById",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetById",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:37.068Z",
+    "timestamp" : "2023-12-06T18:05:50.703Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnClose",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsReset_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
+    "procedureName" : "ActiveCollabsOnClose",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnClose",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:38.242Z",
+    "timestamp" : "2023-12-06T18:05:50.686Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsOnLoad",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T18:05:50.686Z",
+    "type" : 3
+  }, {
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsOnStore",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T18:05:50.660Z",
+    "type" : 3
+  }, {
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsReset",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsReset",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsReset",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T18:05:51.230Z",
+    "type" : 3
+  }, {
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateAssignCollaborator_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignCollaborator_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:41.411Z",
+    "timestamp" : "2023-12-06T18:08:04.894Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateAssignPatient_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:41.876Z",
+    "timestamp" : "2023-12-06T18:08:03.071Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateFindResponders_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateFindResponders_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:40.296Z",
+    "timestamp" : "2023-12-06T18:08:03.401Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:41.816Z",
+    "timestamp" : "2023-12-06T18:08:04.793Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:40.909Z",
+    "timestamp" : "2023-12-06T18:08:03.446Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsUpdateStatus_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
+    "procedureName" : "ActiveCollabsUpdateStatus",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:39.715Z",
+    "timestamp" : "2023-12-06T18:05:51.437Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateTrackResponder_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateTrackResponder_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:42.590Z",
+    "timestamp" : "2023-12-06T18:08:06.234Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsWriteAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
+    "procedureName" : "ActiveCollabsWriteAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:42.043Z",
+    "timestamp" : "2023-12-06T18:05:51.587Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
     "packageName" : "patient.monitoring",
-    "procedureName" : "CollabIdsByEntityStoreId_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
+    "procedureName" : "CollabIdsByEntityStoreId",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:42.634Z",
+    "timestamp" : "2023-12-06T18:05:52.669Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading",
     "name" : "patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "LoopWhileStateGet_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.LoopWhileStateGet_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:32.742Z",
+    "timestamp" : "2023-12-06T18:08:03.291Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.LoopWhileStateReset_MonitorReading",
     "name" : "patient.monitoring.HeartRate.LoopWhileStateReset_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "LoopWhileStateReset_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.LoopWhileStateReset_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:36.402Z",
+    "timestamp" : "2023-12-06T18:08:10.804Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading",
     "name" : "patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "LoopWhileStateUpdate_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.LoopWhileStateUpdate_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:33.511Z",
+    "timestamp" : "2023-12-06T18:08:07.052Z",
     "type" : 3
   }, {
+    "label" : "patient.monitoring.HeartRate.MonitorReading",
     "name" : "patient.monitoring.HeartRate.MonitorReading",
     "resourceReference" : "/types/patient.monitoring.HeartRate.MonitorReading",
-    "timestamp" : "2023-01-26T16:19:29.693Z",
+    "timestamp" : "2023-12-06T18:05:47.626Z",
     "type" : 1
   }, {
+    "label" : "patient.monitoring.HeartRate.MonitorReading",
     "name" : "patient.monitoring.HeartRate.MonitorReading",
     "resourceReference" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading",
-    "timestamp" : "2023-01-26T16:19:30.346Z",
+    "timestamp" : "2023-12-06T18:07:21.345Z",
     "type" : 12
   }, {
     "label" : "patient.monitoring.HeartRate.PartitionedState",
     "name" : "patient.monitoring.HeartRate.PartitionedState",
     "resourceReference" : "/types/patient.monitoring.HeartRate.PartitionedState",
-    "timestamp" : "2023-01-26T16:19:31.870Z",
+    "timestamp" : "2023-12-06T18:05:54.757Z",
     "type" : 1
   }, {
     "label" : "patient.monitoring.HeartRate.generateHeartRate",
@@ -424,13 +453,13 @@
     "procedureName" : "generateHeartRate",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.generateHeartRate",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:19:30.077Z",
+    "timestamp" : "2023-12-06T18:05:49.229Z",
     "type" : 3
   }, {
     "label" : "patient.monitoring.HeartRate.js",
     "name" : "patient.monitoring.HeartRate.js",
     "resourceReference" : "/documents/patient.monitoring.HeartRate.js",
-    "timestamp" : "2023-01-26T16:19:46.917Z",
+    "timestamp" : "2023-12-06T18:06:11.167Z",
     "type" : 19
   } ],
   "tools" : [ {

--- a/Advanced Collaborations/services/patient/monitoring/HeartRate.json
+++ b/Advanced Collaborations/services/patient/monitoring/HeartRate.json
@@ -1,12 +1,24 @@
 {
   "active" : true,
+  "ars_properties" : {
+    "filterGenerated" : false
+  },
   "ars_relationships" : [ ],
+  "collaborationStateConfig" : {
+    "collaboratorRoles" : [ "firstResponder" ],
+    "entityRoles" : [ {
+      "name" : "patient",
+      "type" : "patient.monitoring.HeartRate.MonitorReading"
+    } ],
+    "writeFrequency" : "5 minutes"
+  },
   "description" : null,
   "eventTypes" : {
     "MonitorReading" : {
       "direction" : "INBOUND",
       "eventSchema" : "patient.monitoring.HeartRate.MonitorReading",
-      "implementingResource" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading/EventStream"
+      "implementingResource" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading/EventStream",
+      "isReliable" : false
     }
   },
   "globalType" : null,
@@ -20,11 +32,12 @@
       "type" : "Integer"
     } ]
   } ],
+  "internalEventHandlers" : [ ],
   "name" : "patient.monitoring.HeartRate",
   "partitionedType" : "patient.monitoring.HeartRate.PartitionedState",
   "replicationFactor" : 1,
   "scheduledProcedures" : {
-    "ActiveCollabsWriteAll_MonitorReading" : {
+    "ActiveCollabsWriteAll" : {
       "interval" : 300000
     }
   }

--- a/Introduction to Collaboration/clients/FirstResponderResponse.json
+++ b/Introduction to Collaboration/clients/FirstResponderResponse.json
@@ -61,8 +61,7 @@
   "resourceBinding" : {
     "requiredResources" : [ {
       "resource" : "topics",
-      "resourceId" : "/vantiq/systemmodel/FirstResponderResponse/submitTopic",
-      "type" : "publishes"
+      "resourceId" : "/vantiq/systemmodel/FirstResponderResponse/submitTopic"
     } ]
   },
   "targetDevice" : "mobile",

--- a/Introduction to Collaboration/clients/PatientResponse.json
+++ b/Introduction to Collaboration/clients/PatientResponse.json
@@ -61,8 +61,7 @@
   "resourceBinding" : {
     "requiredResources" : [ {
       "resource" : "topics",
-      "resourceId" : "/vantiq/systemmodel/PatientResponse/submitTopic",
-      "type" : "publishes"
+      "resourceId" : "/vantiq/systemmodel/PatientResponse/submitTopic"
     } ]
   },
   "targetDevice" : "mobile",

--- a/Introduction to Collaboration/collaborationtypes/patient/monitoring/HeartRate/MonitorReading.json
+++ b/Introduction to Collaboration/collaborationtypes/patient/monitoring/HeartRate/MonitorReading.json
@@ -23,6 +23,7 @@
       "ctServiceOpen" : false,
       "serviceGroupOpenHash" : { }
     },
+    "isHidden" : false,
     "paletteWidth" : 170,
     "propertyWidth" : 280
   },
@@ -37,8 +38,9 @@
         "roleType" : "entity"
       },
       "downstreamReferences" : { },
+      "name" : "AssignPatient",
       "pattern" : "Assign",
-      "patternVersion" : 1,
+      "patternVersion" : 7,
       "uuid" : "ad41cf72-bca2-4b06-99af-f6bc8c1468ff"
     },
     "CollabComplete" : {
@@ -47,21 +49,23 @@
         "status" : "completed"
       },
       "downstreamReferences" : { },
+      "name" : "CollabComplete",
       "pattern" : "CollaborationStatus",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "5d4d575e-d0f8-47cc-85d6-2b3784652add"
     },
     "EventStream" : {
       "configuration" : {
         "childStreams" : [ "isUnusualHeartRate" ],
+        "eventTypeName" : "MonitorReading",
         "inboundResource" : "services",
         "inboundResourceId" : "patient.monitoring.HeartRate",
-        "eventTypeName": "MonitorReading",
         "parentStreams" : [ ]
       },
       "downstreamReferences" : { },
+      "name" : "EventStream",
       "pattern" : "EventStream",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "17dafa82-936d-416f-81c5-f87867003413"
     },
     "GetPatient" : {
@@ -73,8 +77,9 @@
         "taskName" : "patient"
       },
       "downstreamReferences" : { },
+      "name" : "GetPatient",
       "pattern" : "GetCollaboration",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "6d5df205-2a62-45a4-a482-ec8cc674f94a"
     },
     "HelpNeeded" : {
@@ -89,8 +94,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "HelpNeeded",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "95aedb54-73c7-4a4a-b760-c88bf2a44b2d"
     },
     "NotifyFirstResponder" : {
@@ -112,8 +118,9 @@
       "downstreamUUIDS" : {
         "response" : "27715a60-ecae-452e-8405-975cb159f628"
       },
+      "name" : "NotifyFirstResponder",
       "pattern" : "Notify",
-      "patternVersion" : 1,
+      "patternVersion" : 6,
       "uuid" : "41b0e8ed-6667-4bb3-8bee-24a993a14310"
     },
     "NotifyPatient" : {
@@ -137,8 +144,9 @@
         "response" : "63a76ed9-15db-42c0-8f37-80953753d6ca",
         "responseTimeout" : "8898cd9f-3b67-43f2-84be-9224f7f88967"
       },
+      "name" : "NotifyPatient",
       "pattern" : "Notify",
-      "patternVersion" : 1,
+      "patternVersion" : 6,
       "uuid" : "93647c35-788d-4d1f-a6a8-9532a3522871"
     },
     "OK" : {
@@ -153,8 +161,9 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "OK",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "8b3a10b2-6569-44d4-8e6b-57b5ee13014f"
     },
     "PatientOK" : {
@@ -163,8 +172,9 @@
         "status" : "completed"
       },
       "downstreamReferences" : { },
+      "name" : "PatientOK",
       "pattern" : "CollaborationStatus",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "f491fcc0-2ebb-4214-8f31-1bc4b4bf60bd"
     },
     "isUnusualHeartRate" : {
@@ -179,21 +189,15 @@
         "upsert" : false
       },
       "downstreamReferences" : { },
+      "name" : "isUnusualHeartRate",
       "pattern" : "Filter",
-      "patternVersion" : 1,
+      "patternVersion" : 4,
       "uuid" : "bfafe3fc-093d-48d9-920c-e5e376af2edb"
     }
   },
-  "boundService" : "patient.monitoring.HeartRate",
-  "collaboratorRoles" : [ ],
   "disableBadging" : false,
-  "entityRoles" : [ {
-    "name" : "patient",
-    "type" : "patient.monitoring.HeartRate.MonitorReading"
-  } ],
   "isComponent" : false,
   "isEventHandler" : true,
   "keyTypes" : [ "system.collaborations" ],
-  "name" : "patient.monitoring.HeartRate.MonitorReading",
-  "writeFrequency" : "5 minutes"
+  "name" : "patient.monitoring.HeartRate.MonitorReading"
 }

--- a/Introduction to Collaboration/projects/PatientMonitor.json
+++ b/Introduction to Collaboration/projects/PatientMonitor.json
@@ -5,9 +5,6 @@
     "target" : "document/patient.monitoring.HeartRate.js"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "topic//patient.monitoring.HeartRate/MonitorReading/handler/inbound"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
     "target" : "procedure/patient.monitoring.HeartRate.generateHeartRate"
   }, {
     "source" : "procedure/patient.monitoring.HeartRate.generateHeartRate",
@@ -23,106 +20,130 @@
     "target" : "topic//vantiq/systemmodel/FirstResponderResponse/submitTopic"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
-    "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "services/patient.monitoring.HeartRate",
     "target" : "type/patient.monitoring.HeartRate.MonitorReading"
   }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
     "target" : "services/patient.monitoring.HeartRate"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading"
-  }, {
-    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
   }, {
     "source" : "services/patient.monitoring.HeartRate",
     "target" : "app/patient.monitoring.HeartRate.MonitorReading"
   }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus"
+  }, {
     "source" : "app/patient.monitoring.HeartRate.MonitorReading",
-    "target" : "type/patient.monitoring.HeartRate.MonitorReading"
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetAll",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsOnClose",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsReset",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
+  }, {
+    "source" : "services/patient.monitoring.HeartRate",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading"
+  }, {
+    "source" : "app/patient.monitoring.HeartRate.MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
+    "target" : "services/patient.monitoring.HeartRate"
+  }, {
+    "source" : "procedure/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
+    "target" : "procedure/patient.monitoring.HeartRate.ActiveCollabsGetById"
   } ],
   "name" : "PatientMonitor",
   "options" : {
@@ -155,6 +176,7 @@
     "v" : 5,
     "viewUUID" : "MAINVIEW"
   },
+  "partitions" : [ ],
   "resources" : [ {
     "label" : "/patient.monitoring.HeartRate/MonitorReading/handler/inbound",
     "name" : "/patient.monitoring.HeartRate/MonitorReading/handler/inbound",
@@ -174,125 +196,141 @@
     "label" : "FirstResponderResponse",
     "name" : "FirstResponderResponse",
     "resourceReference" : "/system.clients/FirstResponderResponse",
-    "timestamp" : "2023-01-26T16:17:07.108Z",
+    "timestamp" : "2023-12-06T17:53:55.499Z",
     "type" : 15
   }, {
     "label" : "PatientResponse",
     "name" : "PatientResponse",
     "resourceReference" : "/system.clients/PatientResponse",
-    "timestamp" : "2023-01-26T16:17:07.108Z",
+    "timestamp" : "2023-12-06T17:53:55.499Z",
     "type" : 15
   }, {
     "label" : "patient.monitoring.HeartRate",
     "name" : "patient.monitoring.HeartRate",
     "resourceReference" : "/system.services/patient.monitoring.HeartRate",
-    "timestamp" : "2023-01-26T16:17:18.071Z",
+    "timestamp" : "2023-12-06T18:03:00.369Z",
     "type" : 63
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsCloseAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsCloseAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsCloseAll_MonitorReading",
+    "procedureName" : "ActiveCollabsCloseAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsCloseAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:12.696Z",
+    "timestamp" : "2023-12-06T17:54:08.170Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsGetAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetAll_MonitorReading",
+    "procedureName" : "ActiveCollabsGetAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:10.506Z",
+    "timestamp" : "2023-12-06T17:54:07.020Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsGetById",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsGetById_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetById_MonitorReading",
+    "procedureName" : "ActiveCollabsGetById",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsGetById",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:09.529Z",
+    "timestamp" : "2023-12-06T17:54:07.032Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnClose",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsReset_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsReset_MonitorReading",
+    "procedureName" : "ActiveCollabsOnClose",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnClose",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:11.061Z",
+    "timestamp" : "2023-12-06T17:54:07.020Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsOnLoad",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnLoad",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T17:54:07.037Z",
+    "type" : 3
+  }, {
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsOnStore",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsOnStore",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T17:54:07.020Z",
+    "type" : 3
+  }, {
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsReset",
+    "packageName" : "patient.monitoring",
+    "procedureName" : "ActiveCollabsReset",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsReset",
+    "serviceName" : "HeartRate",
+    "timestamp" : "2023-12-06T17:54:07.681Z",
+    "type" : 3
+  }, {
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateAssignPatient_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateAssignPatient_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:14.755Z",
+    "timestamp" : "2023-12-06T18:03:05.087Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyFirstResponder_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:13.888Z",
+    "timestamp" : "2023-12-06T18:03:04.382Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "packageName" : "patient.monitoring",
     "procedureName" : "ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateNotifyPatient_MonitorReading",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:13.659Z",
+    "timestamp" : "2023-12-06T18:03:04.991Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsUpdateStatus_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus_MonitorReading",
+    "procedureName" : "ActiveCollabsUpdateStatus",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsUpdateStatus",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:11.738Z",
+    "timestamp" : "2023-12-06T17:54:07.953Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.ActiveCollabsWriteAll",
     "packageName" : "patient.monitoring",
-    "procedureName" : "ActiveCollabsWriteAll_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsWriteAll_MonitorReading",
+    "procedureName" : "ActiveCollabsWriteAll",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.ActiveCollabsWriteAll",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:13.411Z",
+    "timestamp" : "2023-12-06T17:54:08.361Z",
     "type" : 3
   }, {
-    "label" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
-    "name" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
+    "name" : "patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
     "packageName" : "patient.monitoring",
-    "procedureName" : "CollabIdsByEntityStoreId_MonitorReading",
-    "resourceReference" : "/procedures/patient.monitoring.HeartRate.CollabIdsByEntityStoreId_MonitorReading",
+    "procedureName" : "CollabIdsByEntityStoreId",
+    "resourceReference" : "/procedures/patient.monitoring.HeartRate.CollabIdsByEntityStoreId",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:17.434Z",
+    "timestamp" : "2023-12-06T17:54:08.725Z",
     "type" : 3
   }, {
+    "label" : "patient.monitoring.HeartRate.MonitorReading",
     "name" : "patient.monitoring.HeartRate.MonitorReading",
     "resourceReference" : "/types/patient.monitoring.HeartRate.MonitorReading",
-    "timestamp" : "2023-01-26T16:17:07.039Z",
+    "timestamp" : "2023-12-06T17:53:53.416Z",
     "type" : 1
   }, {
+    "label" : "patient.monitoring.HeartRate.MonitorReading",
     "name" : "patient.monitoring.HeartRate.MonitorReading",
     "resourceReference" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading",
-    "timestamp" : "2023-01-26T16:17:07.684Z",
+    "timestamp" : "2023-12-06T17:54:02.707Z",
     "type" : 12
   }, {
     "label" : "patient.monitoring.HeartRate.PartitionedState",
     "name" : "patient.monitoring.HeartRate.PartitionedState",
     "resourceReference" : "/types/patient.monitoring.HeartRate.PartitionedState",
-    "timestamp" : "2023-01-26T16:17:08.672Z",
+    "timestamp" : "2023-12-06T17:54:05.328Z",
     "type" : 1
   }, {
     "label" : "patient.monitoring.HeartRate.generateHeartRate",
@@ -301,13 +339,13 @@
     "procedureName" : "generateHeartRate",
     "resourceReference" : "/procedures/patient.monitoring.HeartRate.generateHeartRate",
     "serviceName" : "HeartRate",
-    "timestamp" : "2023-01-26T16:17:07.412Z",
+    "timestamp" : "2023-12-06T17:53:59.961Z",
     "type" : 3
   }, {
     "label" : "patient.monitoring.HeartRate.js",
     "name" : "patient.monitoring.HeartRate.js",
     "resourceReference" : "/documents/patient.monitoring.HeartRate.js",
-    "timestamp" : "2023-01-26T16:17:18.934Z",
+    "timestamp" : "2023-12-06T17:54:26.811Z",
     "type" : 19
   } ],
   "tools" : [ {

--- a/Introduction to Collaboration/services/patient/monitoring/HeartRate.json
+++ b/Introduction to Collaboration/services/patient/monitoring/HeartRate.json
@@ -1,19 +1,29 @@
 {
   "active" : true,
+  "ars_properties" : {
+    "filterGenerated" : false
+  },
   "ars_relationships" : [ ],
+  "collaborationStateConfig" : {
+    "entityRoles" : [ {
+      "name" : "patient",
+      "type" : "patient.monitoring.HeartRate.MonitorReading"
+    } ],
+    "writeFrequency" : "5 minutes"
+  },
   "description" : null,
   "eventTypes" : {
     "MonitorReading" : {
       "direction" : "INBOUND",
       "eventSchema" : "patient.monitoring.HeartRate.MonitorReading",
-      "implementingResource" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading/EventStream"
+      "implementingResource" : "/collaborationtypes/patient.monitoring.HeartRate.MonitorReading/EventStream",
+      "isReliable" : false
     }
   },
   "globalType" : null,
   "interface" : [ {
     "name" : "generateHeartRate",
     "parameters" : [ {
-      "default" : null,
       "description" : null,
       "multi" : false,
       "name" : "heartRate",
@@ -21,11 +31,12 @@
       "type" : "Integer"
     } ]
   } ],
+  "internalEventHandlers" : [ ],
   "name" : "patient.monitoring.HeartRate",
   "partitionedType" : "patient.monitoring.HeartRate.PartitionedState",
   "replicationFactor" : 1,
   "scheduledProcedures" : {
-    "ActiveCollabsWriteAll_MonitorReading" : {
+    "ActiveCollabsWriteAll" : {
       "interval" : 300000
     }
   }


### PR DESCRIPTION
For the intro tutorial, the main reason for the changes it to pick up the new property locations.  The 1.37 version will actually import just fine, but this makes it a bit cleaner.

The Adv tutorial needed one code change to work in 1.38.

Fixes #105