### PR TITLE
add README for Quickstart tutorial, to show up in Import dialog

### DIFF
--- a/Quickstart/README.md
+++ b/Quickstart/README.md
@@ -1,0 +1,2 @@
+### Quickstart Tutorial
+The Quickstart tutorial walks through using the Design Modeler, a visual IDE tool for building Vantiq systems. It uses the Design Modeler's AI Design Assistant, a UI that allows the user to enter a text description of the system to be built then uses Generative AI to turn that description into the beginnings of the running application. 

--- a/Quickstart/README.md
+++ b/Quickstart/README.md
@@ -1,2 +1,4 @@
 ### Quickstart Tutorial
 The Quickstart tutorial walks through using the Design Modeler, a visual IDE tool for building Vantiq systems. It uses the Design Modeler's AI Design Assistant, a UI that allows the user to enter a text description of the system to be built then uses Generative AI to turn that description into the beginnings of the running application. 
+
+For more information on the Quickstart Tutorial, please see the documentation [here](/docs/system/tutorials/quickstart.md).


### PR DESCRIPTION
noticed that the README was missing for Quickstart