### PR TITLE
fix .md links in READMEs to be index.html

### DIFF
--- a/GenAI Builder/README.md
+++ b/GenAI Builder/README.md
@@ -1,3 +1,3 @@
 ### GenAI Builder Tutorial
 
-This project contains the service and supporting resources created during the [GenAI Builder Tutorial](/docs/system/tutorials/genaibuilder.md).  It demonstrates how to use the [Gen AI Builder](/docs/system/genaibuilder.md) to construct custom GenAI functionality for your applications.
+This project contains the service and supporting resources created during the [GenAI Builder Tutorial](/docs/system/tutorials/genaibuilder/index.html).  It demonstrates how to use the [Gen AI Builder](/docs/system/genaibuilder/index.html) to construct custom GenAI functionality for your applications.

--- a/Introductory/README.md
+++ b/Introductory/README.md
@@ -1,4 +1,4 @@
 ### Introduction to VANTIQ Development
 The Engine Monitor tutorial walks through developing and testing a Vantiq Design Model to monitor the speed and temperature of an engine. The SpeedEvent and TemperatureEvent Inbound Event Types are implemented with Visual Event Handlers to process the stream of sensor readings and detect malfunction conditions in the engine. A Client is used to visualize the data and display any alerts as they occur.
 
-For more information on the Engine Monitor Tutorial, please see the documentation [here](/docs/system/tutorials/tutorial.md).
+For more information on the Engine Monitor Tutorial, please see the documentation [here](/docs/system/tutorials/tutorial/index.html).

--- a/Quickstart/README.md
+++ b/Quickstart/README.md
@@ -1,4 +1,4 @@
 ### Quickstart Tutorial
 The Quickstart tutorial walks through using the Design Modeler, a visual IDE tool for building Vantiq systems. It uses the Design Modeler's AI Design Assistant, a UI that allows the user to enter a text description of the system to be built then uses Generative AI to turn that description into the beginnings of the running application. 
 
-For more information on the Quickstart Tutorial, please see the documentation [here](/docs/system/tutorials/quickstart.md).
+For more information on the Quickstart Tutorial, please see the documentation [here](/docs/system/tutorials/quickstart/index.html).


### PR DESCRIPTION
The .md links only work when running mkdocs post-processing on docs repos, so need to use index.html in these READMEs.

Fixes #111