### PR TITLE
update Conversation Widget tutorial to 1.40 version

### DIFF
--- a/Conversation/README.md
+++ b/Conversation/README.md
@@ -1,4 +1,4 @@
 ### Conversation Widget Tutorial
 The Conversation Widget Tutorial demonstrates how to use a Client Conversation Widget. The Conversation Widget adds chat-like generative AI features to Vantiq Clients.
 
-For more information on the Conversation Widget Tutorial, see the documentation [here](/docs/system/tutorials/conversation/index.html).
+For more information on the Conversation Widget Tutorial, see the documentation [here](/docs/system/tutorials/conversationtutorial/index.html).

--- a/Conversation/clients/MyClient.json
+++ b/Conversation/clients/MyClient.json
@@ -1,4 +1,7 @@
 {
+  "ars_properties" : {
+    "tags" : [ "#launchable" ]
+  },
   "ars_public" : false,
   "ars_relationships" : [ ],
   "controllers" : {
@@ -9,7 +12,7 @@
     "page" : { }
   },
   "isComponent" : false,
-  "isLaunchable" : false,
+  "isLaunchable" : true,
   "models" : {
     "dataObjects" : {
       "__GLOBAL__" : {
@@ -56,7 +59,7 @@
     },
     "description" : "",
     "docAssets" : [ ],
-    "productV" : "7.14",
+    "productV" : "7.14f",
     "showCategoryButtons" : false,
     "showCategoryDataDisplay" : true,
     "showCategoryDataInput" : false,

--- a/Conversation/collaborationtypes/com/vantiq/MyService/Launch.json
+++ b/Conversation/collaborationtypes/com/vantiq/MyService/Launch.json
@@ -5,28 +5,31 @@
     "dataVersion" : 5,
     "graph" : {
       "coordinates" : {
-        "7f8a1e8f-7cd7-4e7b-9762-b4ffdc22deac" : {
-          "x" : 68.47928810119629,
-          "y" : 80
-        },
-        "a36dd8ea-2a4b-46b9-8acb-2b0e3d890206" : {
-          "x" : -52.573814392089844,
-          "y" : 80
-        },
-        "e5ebd158-fa67-4d4e-8b73-d2e971de7b8f" : {
+        "a13d7cff-7d99-4967-89c6-543cb9a7814e" : {
           "x" : 0,
           "y" : 0
+        },
+        "bf85b4bf-b08f-4370-8ab9-753b626c0d77" : {
+          "x" : 68.48686742782593,
+          "y" : 160
+        },
+        "e572eba8-96ea-4d3f-9f52-5d15c23cfd3f" : {
+          "x" : 68.48686742782593,
+          "y" : 80
+        },
+        "f1fb67c9-4b71-4ebc-810d-a303803e5b90" : {
+          "x" : -106.38673543930054,
+          "y" : 80
         }
       },
       "lastZoomRequest" : 0,
-      "scale" : 1.5648235634730225,
-      "translate" : [ 341.91041519325296, 249.43525630507816 ]
+      "scale" : 1.9323614679141004,
+      "translate" : [ 454.4012334328163, 201.3846249214593 ]
     },
     "groupSettings" : {
       "appGroupOpenHash" : {
         "actions" : true,
-        "filters" : true,
-        "flowControl" : true,
+        "collab" : true,
         "mobile" : true
       },
       "ctGroupOpenHash" : {
@@ -36,15 +39,29 @@
       "ctServiceOpen" : false,
       "serviceGroupOpenHash" : { }
     },
-    "isHidden" : false,
     "paletteWidth" : 170,
     "propertyWidth" : 280
   },
   "ars_relationships" : [ ],
   "assembly" : {
+    "EstablishCollaboration" : {
+      "configuration" : {
+        "behavior" : "Establish existing collaboration or create new collaboration",
+        "childStreams" : [ "Notify" ],
+        "collaborationId" : null,
+        "entityId" : "event.myEntityId",
+        "parentStreams" : [ "EventStream" ],
+        "roleName" : "myEntityId"
+      },
+      "downstreamReferences" : { },
+      "name" : "EstablishCollaboration",
+      "pattern" : "EstablishCollaboration",
+      "patternVersion" : 9,
+      "uuid" : "e572eba8-96ea-4d3f-9f52-5d15c23cfd3f"
+    },
     "EventStream" : {
       "configuration" : {
-        "childStreams" : [ "LogStream", "Notify" ],
+        "childStreams" : [ "LogStream", "EstablishCollaboration" ],
         "eventTypeName" : "Launch",
         "inboundResource" : "services",
         "inboundResourceId" : "com.vantiq.MyService",
@@ -54,7 +71,7 @@
       "name" : "EventStream",
       "pattern" : "EventStream",
       "patternVersion" : 5,
-      "uuid" : "e5ebd158-fa67-4d4e-8b73-d2e971de7b8f"
+      "uuid" : "a13d7cff-7d99-4967-89c6-543cb9a7814e"
     },
     "LogStream" : {
       "configuration" : {
@@ -65,7 +82,7 @@
       "name" : "LogStream",
       "pattern" : "LogStream",
       "patternVersion" : 2,
-      "uuid" : "a36dd8ea-2a4b-46b9-8acb-2b0e3d890206"
+      "uuid" : "f1fb67c9-4b71-4ebc-810d-a303803e5b90"
     },
     "Notify" : {
       "configuration" : {
@@ -75,7 +92,7 @@
         "firstResponseFilter" : null,
         "imports" : null,
         "maxResponseTime" : null,
-        "parentStreams" : [ "EventStream" ],
+        "parentStreams" : [ "EstablishCollaboration" ],
         "pushSourceName" : null,
         "title" : "\"Test Conversation Widget\"",
         "users" : "[Context.username()]"
@@ -84,7 +101,7 @@
       "name" : "Notify",
       "pattern" : "Notify",
       "patternVersion" : 7,
-      "uuid" : "7f8a1e8f-7cd7-4e7b-9762-b4ffdc22deac"
+      "uuid" : "bf85b4bf-b08f-4370-8ab9-753b626c0d77"
     }
   },
   "contextualizedAssembly" : { },

--- a/Conversation/collaborationtypes/com/vantiq/MyService/Launch.json
+++ b/Conversation/collaborationtypes/com/vantiq/MyService/Launch.json
@@ -22,9 +22,9 @@
           "y" : 80
         }
       },
-      "lastZoomRequest" : 0,
-      "scale" : 1.9323614679141004,
-      "translate" : [ 454.4012334328163, 201.3846249214593 ]
+      "lastZoomRequest" : 3,
+      "scale" : 1.4551410747395215,
+      "translate" : [ 269.0120344003679, 318.08871402083827 ]
     },
     "groupSettings" : {
       "appGroupOpenHash" : {
@@ -39,6 +39,7 @@
       "ctServiceOpen" : false,
       "serviceGroupOpenHash" : { }
     },
+    "isHidden" : false,
     "paletteWidth" : 170,
     "propertyWidth" : 280
   },

--- a/Conversation/collaborationtypes/com/vantiq/MyService/Prompt.json
+++ b/Conversation/collaborationtypes/com/vantiq/MyService/Prompt.json
@@ -5,26 +5,30 @@
     "dataVersion" : 5,
     "graph" : {
       "coordinates" : {
-        "34d78ef0-45f5-4200-869f-d36900e0c120" : {
+        "1529e6a9-3a88-4c59-a3f0-d7c01b8d180a" : {
           "x" : 0,
           "y" : 80
         },
-        "40d8a13f-907e-40e2-8aee-b547792e9970" : {
+        "26d582f5-8753-4161-b9a1-eaf485fd1921" : {
+          "x" : 0,
+          "y" : 320
+        },
+        "413be781-706f-43de-8b18-6e2d63a95b38" : {
           "x" : 0,
           "y" : 160
         },
-        "66ae8a96-5244-48f5-81bb-975f7d2369b4" : {
-          "x" : 0,
-          "y" : 0
-        },
-        "8b00f8f6-149f-4108-80cf-335530171374" : {
+        "ba3489c9-edcf-407f-8857-ba7c2269c9c8" : {
           "x" : 0,
           "y" : 240
+        },
+        "f585b764-5c20-4183-96bb-7e71b6b255ce" : {
+          "x" : 0,
+          "y" : 0
         }
       },
       "lastZoomRequest" : 0,
-      "scale" : 1.4419288714602236,
-      "translate" : [ 333.95979417247963, 138.86059507389257 ]
+      "scale" : 1.8702738208229774,
+      "translate" : [ 769.0544893663421, 143.94131719566417 ]
     },
     "groupSettings" : {
       "appGroupOpenHash" : {
@@ -32,7 +36,8 @@
         "ai" : true,
         "collab" : true,
         "filters" : true,
-        "flowControl" : true
+        "flowControl" : true,
+        "modifiers" : true
       },
       "ctGroupOpenHash" : {
         "actions" : true,
@@ -49,18 +54,18 @@
   "assembly" : {
     "EstablishCollaboration" : {
       "configuration" : {
-        "behavior" : "Establish existing collaboration",
+        "behavior" : "Establish existing collaboration or create new collaboration",
         "childStreams" : [ "SubmitPrompt" ],
-        "collaborationId" : "event.collaborationId",
-        "entityId" : null,
+        "collaborationId" : null,
+        "entityId" : "event.myEntityId",
         "parentStreams" : [ "EventStream" ],
-        "roleName" : null
+        "roleName" : "myEntityId"
       },
       "downstreamReferences" : { },
       "name" : "EstablishCollaboration",
       "pattern" : "EstablishCollaboration",
       "patternVersion" : 9,
-      "uuid" : "34d78ef0-45f5-4200-869f-d36900e0c120"
+      "uuid" : "1529e6a9-3a88-4c59-a3f0-d7c01b8d180a"
     },
     "EventStream" : {
       "configuration" : {
@@ -74,13 +79,13 @@
       "name" : "EventStream",
       "pattern" : "EventStream",
       "patternVersion" : 5,
-      "uuid" : "66ae8a96-5244-48f5-81bb-975f7d2369b4"
+      "uuid" : "f585b764-5c20-4183-96bb-7e71b6b255ce"
     },
     "PublishToService" : {
       "configuration" : {
         "childStreams" : null,
         "eventTypeName" : "Response",
-        "parentStreams" : [ "SubmitPrompt" ],
+        "parentStreams" : [ "Transformation" ],
         "processedByClause" : null,
         "service" : "com.vantiq.MyService"
       },
@@ -88,11 +93,11 @@
       "name" : "PublishToService",
       "pattern" : "PublishToService",
       "patternVersion" : 3,
-      "uuid" : "8b00f8f6-149f-4108-80cf-335530171374"
+      "uuid" : "26d582f5-8753-4161-b9a1-eaf485fd1921"
     },
     "SubmitPrompt" : {
       "configuration" : {
-        "childStreams" : [ "PublishToService" ],
+        "childStreams" : [ "Transformation" ],
         "conversationName" : null,
         "functionAuthorizer" : null,
         "functions" : null,
@@ -109,7 +114,31 @@
       "name" : "SubmitPrompt",
       "pattern" : "SubmitPrompt",
       "patternVersion" : 5,
-      "uuid" : "40d8a13f-907e-40e2-8aee-b547792e9970"
+      "uuid" : "413be781-706f-43de-8b18-6e2d63a95b38"
+    },
+    "Transformation" : {
+      "configuration" : {
+        "childStreams" : [ "PublishToService" ],
+        "imports" : null,
+        "outboundResource" : null,
+        "outboundResourceConfig" : null,
+        "outboundResourceId" : null,
+        "parentStreams" : [ "SubmitPrompt" ],
+        "schema" : null,
+        "transformInPlace" : true,
+        "transformation" : {
+          "collaborationId" : {
+            "expression" : "event.collaborationId",
+            "type" : "expression"
+          }
+        },
+        "upsert" : false
+      },
+      "downstreamReferences" : { },
+      "name" : "Transformation",
+      "pattern" : "Transformation",
+      "patternVersion" : 5,
+      "uuid" : "ba3489c9-edcf-407f-8857-ba7c2269c9c8"
     }
   },
   "contextualizedAssembly" : { },

--- a/Conversation/collaborationtypes/com/vantiq/MyService/Prompt.json
+++ b/Conversation/collaborationtypes/com/vantiq/MyService/Prompt.json
@@ -26,9 +26,9 @@
           "y" : 0
         }
       },
-      "lastZoomRequest" : 0,
-      "scale" : 1.8702738208229774,
-      "translate" : [ 769.0544893663421, 143.94131719566417 ]
+      "lastZoomRequest" : 3,
+      "scale" : 2.257142857142857,
+      "translate" : [ 269, 73.35714285714289 ]
     },
     "groupSettings" : {
       "appGroupOpenHash" : {

--- a/Conversation/projects/Conversation.json
+++ b/Conversation/projects/Conversation.json
@@ -2,46 +2,19 @@
   "ars_relationships" : [ ],
   "links" : [ {
     "source" : "services/com.vantiq.MyService",
-    "target" : "document/com.vantiq.MyService.js"
+    "target" : "type/com.vantiq.MyType"
   }, {
     "source" : "services/com.vantiq.MyService",
-    "target" : "type/com.vantiq.MyService.PartitionedState"
+    "target" : "document/com.vantiq.MyService.js"
   }, {
     "source" : "services/com.vantiq.MyService",
     "target" : "app/com.vantiq.MyService.Launch"
   }, {
     "source" : "services/com.vantiq.MyService",
-    "target" : "app/com.vantiq.MyService.Prompt"
-  }, {
-    "source" : "services/com.vantiq.MyService",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateStatus"
   }, {
     "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.CollabIdsByEntityStoreId"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore"
-  }, {
-    "source" : "services/com.vantiq.MyService",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnLoad"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetAll"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
   }, {
     "source" : "services/com.vantiq.MyService",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsReset"
@@ -50,34 +23,40 @@
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll"
   }, {
     "source" : "services/com.vantiq.MyService",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt"
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
-    "target" : "services/com.vantiq.MyService"
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetAll"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
+    "source" : "services/com.vantiq.MyService",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
-    "target" : "services/com.vantiq.MyService"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll",
-    "target" : "services/com.vantiq.MyService"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
-    "target" : "services/com.vantiq.MyService"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
+    "source" : "services/com.vantiq.MyService",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll"
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Launch"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.CollabIdsByEntityStoreId"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "type/com.vantiq.MyService.PartitionedState"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateStatus",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateStatus",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose"
   }, {
     "source" : "app/com.vantiq.MyService.Launch",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
@@ -85,57 +64,120 @@
     "source" : "app/com.vantiq.MyService.Launch",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsReset",
+    "source" : "app/com.vantiq.MyService.Launch",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
     "target" : "services/com.vantiq.MyService"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose",
-    "target" : "services/com.vantiq.MyService"
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll"
   }, {
-    "source" : "app/com.vantiq.MyService.Prompt",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
-  }, {
-    "source" : "app/com.vantiq.MyService.Prompt",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetById",
-    "target" : "services/com.vantiq.MyService"
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsCloseAll",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose"
   }, {
     "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetById",
     "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnLoad"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt",
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetById",
     "target" : "services/com.vantiq.MyService"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateStatus",
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
     "target" : "services/com.vantiq.MyService"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetAll",
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Launch",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Launch"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
     "target" : "services/com.vantiq.MyService"
   }, {
     "source" : "procedure/com.vantiq.MyService.CollabIdsByEntityStoreId",
     "target" : "services/com.vantiq.MyService"
   }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetAll",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsReset",
+    "target" : "services/com.vantiq.MyService"
+  }, {
     "source" : "procedure/com.vantiq.MyService.ActiveCollabsOnLoad",
     "target" : "services/com.vantiq.MyService"
   }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore",
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "app/com.vantiq.MyService.Prompt"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "app/com.vantiq.MyService.Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt"
+  }, {
+    "source" : "app/com.vantiq.MyService.Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsGetById"
+  }, {
+    "source" : "app/com.vantiq.MyService.Prompt",
+    "target" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.Transformation_Prompt",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "services/com.vantiq.MyService",
+    "target" : "procedure/com.vantiq.MyService.Transformation_Prompt"
+  }, {
+    "source" : "procedure/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt",
+    "target" : "services/com.vantiq.MyService"
+  }, {
+    "source" : "app/com.vantiq.MyService.Prompt",
     "target" : "services/com.vantiq.MyService"
   }, {
     "source" : "app/com.vantiq.MyService.Launch",
     "target" : "services/com.vantiq.MyService"
-  }, {
-    "source" : "services/com.vantiq.MyService",
-    "target" : "client/MyClient"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsUpdateStatus",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnClose"
-  }, {
-    "source" : "procedure/com.vantiq.MyService.ActiveCollabsWriteAll",
-    "target" : "procedure/com.vantiq.MyService.ActiveCollabsOnStore"
   } ],
   "name" : "Conversation",
   "options" : {
-    "description" : "The [Conversation Tutorial](/docs/system/tutorials/conversation/index.html) demonstrates how to use a Client Conversation Widget. The Conversation Widget adds chat-like generative AI features to Vantiq Clients.\n\nThis tutorial uses an [OpenAI LLM](https://openai.com/), gpt-3.5-turbo, which requires an API Key. To add the API Key secret, select the _Add a New Secret_ menu item from the **API Key Secret** menu in the _MyLLM_ pane below. Call the secret \"OpenAI\" and enter your OpenAI Key in the **API Key Secret** property. Save the LLM.\n\nTo send the Client to the Vantiq iOS or Android app, click the **Interface** tab in the com.vantiq.MyService pane to the right, open the **Inbound** section, then click the _Launch_ entry. Open the **Publish** section and click the **Publish** button. This will add an Inbox item to the mobile app. Click the Inbox item to launch the Client that contains the sample Conversation Widget.",
+    "description" : "The [Conversation Tutorial](/docs/system/tutorials/conversationtutorial/index.html) demonstrates how to use a Client Conversation Widget. The Conversation Widget adds chat-like generative AI features to Vantiq Clients.\n\nThis tutorial uses an [OpenAI LLM](https://openai.com/), gpt-3.5-turbo, which requires an API Key. To add the API Key secret, select the _Add a New Secret_ menu item from the **API Key Secret** menu in the _MyLLM_ pane below. Call the secret \"OpenAI\" and enter your OpenAI Key in the **API Key Secret** property. Save the LLM.\n\nTo send the Client to the Vantiq iOS or Android app, click the **Interface** tab in the com.vantiq.MyService pane to the left, open the **Inbound** section, then click the _Launch_ entry. Open the **Publish** section and click the **Publish** button. This will add an Inbox item to the mobile app. Click the Inbox item to launch the Client that contains the sample Conversation Widget.",
     "dockCollapsed" : {
       "bottom" : true,
       "left" : false,
@@ -151,19 +193,26 @@
       "top" : 0,
       "viewtabs" : 0
     },
-    "dockSort" : 1,
-    "exclusionList" : [ "llm/com.vantiq.michael.MyLLM" ],
     "filterBitArray" : "ffffffffffffffffffffffffffffffff",
     "isModeloProject" : true,
-    "layoutStyle" : "tile",
-    "openFolders" : [ "client", "com.vantiq", "com.vantiq/services", "llm" ],
+    "layoutStyle" : "flex",
+    "openFolders" : [ "com.vantiq", "com.vantiq.MyService", "com.vantiq/type" ],
     "partitionsSettings" : { },
     "rootViewFlavor" : 5,
     "showGrid" : true,
-    "tileColumns" : 2,
-    "tileRows" : 2,
+    "structure" : {
+      "fraction" : 1,
+      "groups" : [ {
+        "fraction" : 0.7220496894409938,
+        "type" : "L[4]"
+      }, {
+        "fraction" : 0.2779503105590062,
+        "type" : "L[1]"
+      } ],
+      "type" : "RH"
+    },
     "type" : "dev",
-    "v" : 5,
+    "v" : 6,
     "viewUUID" : "MAINVIEW"
   },
   "partitions" : [ ],
@@ -171,19 +220,19 @@
     "label" : "MyClient",
     "name" : "MyClient",
     "resourceReference" : "/system.clients/MyClient",
-    "timestamp" : "2024-05-24T17:33:13.509Z",
+    "timestamp" : "2024-07-26T22:56:39.913Z",
     "type" : 15
   }, {
     "label" : "MyLLM",
     "name" : "MyLLM",
     "resourceReference" : "/system.llms/MyLLM",
-    "timestamp" : "2024-05-24T17:33:13.008Z",
+    "timestamp" : "2024-07-26T22:56:40.407Z",
     "type" : 80
   }, {
     "label" : "com.vantiq.MyService",
     "name" : "com.vantiq.MyService",
-    "resourceReference" : "/system.services/com.vantiq.MyService",
-    "timestamp" : "2024-05-24T17:52:19.085Z",
+    "resourceReference" : "/services/com.vantiq.MyService",
+    "timestamp" : "2024-07-26T23:10:20.343Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsCloseAll",
@@ -192,7 +241,7 @@
     "procedureName" : "ActiveCollabsCloseAll",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsCloseAll",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:15.515Z",
+    "timestamp" : "2024-07-26T22:56:44.370Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsGetAll",
@@ -201,7 +250,16 @@
     "procedureName" : "ActiveCollabsGetAll",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsGetAll",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:14.617Z",
+    "timestamp" : "2024-07-26T22:56:42.643Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
+    "name" : "com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
+    "packageName" : "com.vantiq",
+    "procedureName" : "ActiveCollabsGetByEntityId_Launch",
+    "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsGetByEntityId_Launch",
+    "serviceName" : "MyService",
+    "timestamp" : "2024-07-26T22:56:55.576Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
@@ -210,7 +268,7 @@
     "procedureName" : "ActiveCollabsGetByEntityId_Prompt",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsGetByEntityId_Prompt",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:16.740Z",
+    "timestamp" : "2024-07-26T22:56:55.544Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsGetById",
@@ -219,7 +277,7 @@
     "procedureName" : "ActiveCollabsGetById",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsGetById",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:14.620Z",
+    "timestamp" : "2024-07-26T22:56:42.653Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsOnClose",
@@ -228,7 +286,7 @@
     "procedureName" : "ActiveCollabsOnClose",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsOnClose",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:14.630Z",
+    "timestamp" : "2024-07-26T22:56:42.597Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsOnLoad",
@@ -237,7 +295,7 @@
     "procedureName" : "ActiveCollabsOnLoad",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsOnLoad",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:14.622Z",
+    "timestamp" : "2024-07-26T22:56:42.604Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsOnStore",
@@ -246,7 +304,7 @@
     "procedureName" : "ActiveCollabsOnStore",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsOnStore",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:14.617Z",
+    "timestamp" : "2024-07-26T22:56:42.648Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsReset",
@@ -255,7 +313,16 @@
     "procedureName" : "ActiveCollabsReset",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsReset",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:15.105Z",
+    "timestamp" : "2024-07-26T22:56:43.779Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.MyService.ActiveCollabsSetEntity_Launch",
+    "name" : "com.vantiq.MyService.ActiveCollabsSetEntity_Launch",
+    "packageName" : "com.vantiq",
+    "procedureName" : "ActiveCollabsSetEntity_Launch",
+    "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsSetEntity_Launch",
+    "serviceName" : "MyService",
+    "timestamp" : "2024-07-26T22:56:57.491Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsSetEntity_Prompt",
@@ -264,7 +331,7 @@
     "procedureName" : "ActiveCollabsSetEntity_Prompt",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsSetEntity_Prompt",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:18.173Z",
+    "timestamp" : "2024-07-26T22:56:58.743Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
@@ -273,7 +340,7 @@
     "procedureName" : "ActiveCollabsUpdateNotify_Launch",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsUpdateNotify_Launch",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:17.382Z",
+    "timestamp" : "2024-07-26T22:56:55.570Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsUpdateStatus",
@@ -282,7 +349,16 @@
     "procedureName" : "ActiveCollabsUpdateStatus",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsUpdateStatus",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:15.159Z",
+    "timestamp" : "2024-07-26T22:56:43.954Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "name" : "com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "packageName" : "com.vantiq",
+    "procedureName" : "ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsUpdateSubmitPrompt_Prompt",
+    "serviceName" : "MyService",
+    "timestamp" : "2024-07-26T22:56:55.577Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.ActiveCollabsWriteAll",
@@ -291,7 +367,7 @@
     "procedureName" : "ActiveCollabsWriteAll",
     "resourceReference" : "/procedures/com.vantiq.MyService.ActiveCollabsWriteAll",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:16.140Z",
+    "timestamp" : "2024-07-26T22:56:45.105Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.CollabIdsByEntityStoreId",
@@ -300,32 +376,47 @@
     "procedureName" : "CollabIdsByEntityStoreId",
     "resourceReference" : "/procedures/com.vantiq.MyService.CollabIdsByEntityStoreId",
     "serviceName" : "MyService",
-    "timestamp" : "2024-05-24T17:33:15.616Z",
+    "timestamp" : "2024-07-26T22:56:44.973Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.MyService.Launch",
     "name" : "com.vantiq.MyService.Launch",
     "resourceReference" : "/collaborationtypes/com.vantiq.MyService.Launch",
-    "timestamp" : "2024-05-24T17:33:14.088Z",
+    "timestamp" : "2024-07-26T23:10:19.797Z",
     "type" : 12
   }, {
     "label" : "com.vantiq.MyService.PartitionedState",
     "name" : "com.vantiq.MyService.PartitionedState",
     "resourceReference" : "/types/com.vantiq.MyService.PartitionedState",
-    "timestamp" : "2024-05-24T17:33:14.257Z",
+    "timestamp" : "2024-07-26T22:56:42.092Z",
     "type" : 1
   }, {
     "label" : "com.vantiq.MyService.Prompt",
     "name" : "com.vantiq.MyService.Prompt",
     "resourceReference" : "/collaborationtypes/com.vantiq.MyService.Prompt",
-    "timestamp" : "2024-05-24T17:52:18.595Z",
+    "timestamp" : "2024-07-26T22:56:41.598Z",
     "type" : 12
+  }, {
+    "label" : "com.vantiq.MyService.Transformation_Prompt",
+    "name" : "com.vantiq.MyService.Transformation_Prompt",
+    "packageName" : "com.vantiq",
+    "procedureName" : "Transformation_Prompt",
+    "resourceReference" : "/procedures/com.vantiq.MyService.Transformation_Prompt",
+    "serviceName" : "MyService",
+    "timestamp" : "2024-07-26T22:56:55.381Z",
+    "type" : 3
   }, {
     "label" : "com.vantiq.MyService.js",
     "name" : "com.vantiq.MyService.js",
     "resourceReference" : "/documents/com.vantiq.MyService.js",
-    "timestamp" : "2024-05-24T17:52:20.011Z",
+    "timestamp" : "2024-07-26T22:57:02.141Z",
     "type" : 19
+  }, {
+    "label" : "com.vantiq.MyType",
+    "name" : "com.vantiq.MyType",
+    "resourceReference" : "/types/com.vantiq.MyType",
+    "timestamp" : "2024-07-26T22:56:39.538Z",
+    "type" : 1
   } ],
   "tools" : [ {
     "isPinned" : false,
@@ -340,21 +431,22 @@
     "isPinned" : false,
     "name" : "MyClient",
     "pane" : {
-      "c" : 1,
-      "r" : 1
+      "address" : "RH[0]/L[1]"
     },
     "resourceKey" : "client/MyClient",
-    "state" : 2,
+    "state" : 8,
+    "toolOptions" : {
+      "isRunning" : false
+    },
     "type" : 63
   }, {
     "isPinned" : false,
     "name" : "MyLLM",
     "pane" : {
-      "c" : 0,
-      "r" : 1
+      "address" : "RH[0]/L[3]"
     },
     "resourceKey" : "llm/MyLLM",
-    "state" : 2,
+    "state" : 8,
     "type" : 9
   }, {
     "isPinned" : false,
@@ -364,25 +456,35 @@
     "isPinned" : false,
     "name" : "Project Description",
     "pane" : {
-      "c" : 0,
-      "r" : 0
+      "address" : "RH[1]/L[0]",
+      "isActive" : true
     },
-    "state" : 2,
+    "state" : 8,
     "type" : 82
   }, {
     "isPinned" : false,
     "name" : "com.vantiq.MyService",
     "pane" : {
-      "c" : 1,
-      "r" : 0
+      "address" : "RH[0]/L[0]",
+      "isActive" : true,
+      "isActiveTool" : true
     },
     "resourceKey" : "services/com.vantiq.MyService",
-    "state" : 2,
+    "state" : 8,
     "type" : 109
+  }, {
+    "isPinned" : false,
+    "name" : "com.vantiq.MyType",
+    "pane" : {
+      "address" : "RH[0]/L[2]"
+    },
+    "resourceKey" : "type/com.vantiq.MyType",
+    "state" : 8,
+    "type" : 6
   } ],
   "type" : "dev",
   "views" : [ {
     "name" : "Project Contents",
-    "projectToolKeys" : [ "errorviewer/Errors", "tiledock/Inactive Panes", "client/MyClient", "llmeeditor/MyLLM", "list/Project Contents", "projectdescription/Project Description", "services/com.vantiq.MyService" ]
+    "projectToolKeys" : [ "errorviewer/Errors", "tiledock/Inactive Panes", "client/MyClient", "llmeeditor/MyLLM", "list/Project Contents", "projectdescription/Project Description", "services/com.vantiq.MyService", "subtypeeditor/com.vantiq.MyType" ]
   } ]
 }

--- a/Conversation/services/com/vantiq/MyService.json
+++ b/Conversation/services/com/vantiq/MyService.json
@@ -2,13 +2,21 @@
   "active" : true,
   "ars_properties" : {
     "filterPrivateGenerated" : false,
-    "filterPublicGenerated" : true
+    "filterPublicGenerated" : false
   },
   "ars_relationships" : [ ],
+  "collaborationStateConfig" : {
+    "entityRoles" : [ {
+      "name" : "myEntityId",
+      "type" : "com.vantiq.MyType"
+    } ],
+    "writeFrequency" : "5 minutes"
+  },
   "description" : null,
   "eventTypes" : {
     "Launch" : {
       "direction" : "INBOUND",
+      "eventSchema" : "com.vantiq.MyType",
       "implementingResource" : "/collaborationtypes/com.vantiq.MyService.Launch/EventStream",
       "isReliable" : false
     },

--- a/Conversation/types/com/vantiq/MyType.json
+++ b/Conversation/types/com/vantiq/MyType.json
@@ -1,0 +1,16 @@
+{
+  "ars_properties" : null,
+  "ars_relationships" : [ ],
+  "groupBy" : "",
+  "name" : "com.vantiq.MyType",
+  "properties" : {
+    "myEntityId" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    }
+  },
+  "role" : "schema"
+}


### PR DESCRIPTION
@steve-langley has updated the Conversation Widget tutorial for 1.40.
It now uses a collaboration to hold the conversation id.
That included adding an Entity Role and creating a type to hold the entityId

Also corrected the tutorial-doc link in project description and README.

Fixes  #116