### PR TITLE
update mode to chunking_strategy in GenAI loadFromUrl

### DIFF
--- a/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
+++ b/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
@@ -52,7 +52,7 @@
     "UnstructuredURL": {
       "component": "io.vantiq.ai.components.loaders.UnstructuredURL",
       "configuration": {
-        "mode": "paged",
+        "chunking_strategy": "by_paged",
         "encoding": "utf-8",
         "strategy": "fast"
       },

--- a/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
+++ b/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
@@ -52,7 +52,7 @@
     "UnstructuredURL": {
       "component": "io.vantiq.ai.components.loaders.UnstructuredURL",
       "configuration": {
-        "chunking_strategy": "by_paged",
+        "chunking_strategy": "by_page",
         "encoding": "utf-8",
         "strategy": "fast"
       },


### PR DESCRIPTION
Update GenAI Tutorial to use chunking_strategy instead of mode for v1.41 
Fixes #125 
