### PR TITLE
Update export format for GenAI UnstructuredUrl AP to match 1.42 format

### DIFF
--- a/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
+++ b/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_loadFromUrl.json
@@ -75,7 +75,10 @@
     "storeIndexEntry": {
       "component": "io.vantiq.ai.components.SemanticIndexStore",
       "configuration": {
-        "semanticIndex": "com.vantiq.genai.TestLoadingIndex"
+        "semanticIndex": {
+          "type": "semanticindexes",
+          "value": "com.vantiq.genai.TestLoadingIndex"
+        }
       },
       "enableAuditing": false,
       "children": []

--- a/GenAI Builder/semanticindexes/com/vantiq/genai/TutorialIndex.json
+++ b/GenAI Builder/semanticindexes/com/vantiq/genai/TutorialIndex.json
@@ -1,7 +1,7 @@
 {
   "ars_relationships" : [ ],
   "databaseConfig" : { },
-  "defaultMinSimilarity" : 0.75,
+  "defaultMinSimilarity" : 0.6,
   "embeddingModel" : "SentenceTransformer",
   "name" : "com.vantiq.genai.TutorialIndex"
 }


### PR DESCRIPTION
update UnstructuredURL task to use Union property to match 1.42 change that ActivityPattern.

Also change similarity score for TutorialIndex per #123 so that RAG GenAIFlow _workedAtForte_ gets the right answer again.

Fixes #128
Fixes #123 

