### PR TITLE
update NativeLCEL example in GenAI tutorial to use langchain_classic.retrievers

### DIFF
--- a/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_contextualCompression.json
+++ b/GenAI Builder/genaiflows/com/vantiq/genai/TutorialService_contextualCompression.json
@@ -59,7 +59,7 @@
       "configuration": {
         "lcelConfig": {},
         "codeBlock": {
-          "code": "from langchain.retrievers import ContextualCompressionRetriever\nfrom langchain.retrievers.document_compressors import LLMChainExtractor\nfrom vantiq.resources import SemanticIndex, LLM\n\nretriever = SemanticIndex(client_context, si_name=\"com.vantiq.genai.StateOfUnion\")\nllm = LLM(\"GPT_LLM\", client_context)\ncompressor = LLMChainExtractor.from_llm(llm)\ncompression_retriever = ContextualCompressionRetriever(\n    base_compressor=compressor, base_retriever=retriever\n)\nreturn compression_retriever",
+          "code": "from langchain_classic.retrievers import ContextualCompressionRetriever\nfrom langchain_classic.retrievers.document_compressors import LLMChainExtractor\nfrom vantiq.resources import SemanticIndex, LLM\n\nretriever = SemanticIndex(client_context, si_name=\"com.vantiq.genai.StateOfUnion\")\nllm = LLM(\"GPT_LLM\", client_context)\ncompressor = LLMChainExtractor.from_llm(llm)\ncompression_retriever = ContextualCompressionRetriever(\n    base_compressor=compressor, base_retriever=retriever\n)\nreturn compression_retriever",
           "language": "python"
         }
       },


### PR DESCRIPTION
This is for use with langchain 1.x, which is part of v1.44

Fixes #136